### PR TITLE
add top component validation in sections

### DIFF
--- a/lib/schemas/edit-new/modules/sections/commonProperties.js
+++ b/lib/schemas/edit-new/modules/sections/commonProperties.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const actions = require('../../../common/actions');
+const topComponents = require('./topComponents');
+
+module.exports = {
+	actions,
+	topComponents
+};

--- a/lib/schemas/edit-new/modules/sections/topComponents.js
+++ b/lib/schemas/edit-new/modules/sections/topComponents.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+	type: 'object',
+	properties: {
+		components: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					component: { type: 'string' },
+					attributes: {
+						type: 'object',
+						additionalProperties: true
+					}
+				},
+				required: ['component'],
+				additionalProperties: false
+			},
+			minItems: 1
+		}
+	},
+	minProperties: 1,
+	additionalProperties: false
+};

--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -2,15 +2,13 @@
 
 const { properties, required } = require('../common/base');
 const sections = require('./modules/sections');
-const actions = require('../common/actions');
 const sectionNames = require('./modules/sectionsNames');
 const { makeSection } = require('../../schemas/utils');
+const commonSectionProperties = require('./modules/sections/commonProperties');
 
 const sectionsModified = sections.map(section => (
 	makeSection(section, {
-		properties: {
-			actions
-		}
+		properties: commonSectionProperties
 	})
 ));
 

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -16,6 +16,9 @@ sections:
       type: link
       options:
         path: /service/namespace/new
+  topComponents:
+    components:
+      - component: TestComponent
   fieldsGroup:
   - name: detail
     position: left
@@ -71,6 +74,16 @@ sections:
               value: 0
 - name: semaphoreBrowse
   rootComponent: BrowseSection
+  topComponents:
+    components:
+      - component: TestComponent
+        attributes:
+          name: test
+          sarasa: test23
+      - component: TestComponent2
+        attributes:
+          name: test
+          sarasa: test23
   source:
     service: sac
     namespace: claim-semaphore

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -23,6 +23,13 @@
                     }
                 }
             ],
+            "topComponents": {
+                "components": [
+                    {
+                        "component": "TestComponent"
+                    }
+                ]
+            },
             "fieldsGroup": [
                 {
                     "name": "detail",
@@ -154,6 +161,24 @@
                 "namespace": "claim-semaphore",
                 "method": "browse",
                 "resolve": false
+            },
+            "topComponents": {
+                "components": [
+                    {
+                        "component": "TestComponent",
+                        "attributes": {
+                            "name": "test",
+                            "sarasa": "test23"
+                        }
+                    },
+                    {
+                        "component": "TestComponent2",
+                        "attributes": {
+                            "name": "test",
+                            "sarasa": "test23"
+                        }
+                    }
+                ]
             },
             "fields": [
                 {


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-569

DESCRIPCIÓN DEL REQUERIMIENTO

Escenario #1: Validación de back

Se debe validar un nuevo campo **topComponents** dentro de todos los EditSections, el cual reciba las siguientes props:

**components**: Array de objetos con las siguientes props:
**component**: nombres del componente.
**attributes**: objeto opcional libre de atributos

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego la el schema pra topComponents con sus respectivas properties y se lo agrego a las properties custom de las sections de edit y new

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README