### PR TITLE
fix topComponent validation

### DIFF
--- a/lib/schemas/edit-new/modules/sections/topComponents.js
+++ b/lib/schemas/edit-new/modules/sections/topComponents.js
@@ -1,25 +1,18 @@
 'use strict';
 
 module.exports = {
-	type: 'object',
-	properties: {
-		components: {
-			type: 'array',
-			items: {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			component: { type: 'string' },
+			attributes: {
 				type: 'object',
-				properties: {
-					component: { type: 'string' },
-					attributes: {
-						type: 'object',
-						additionalProperties: true
-					}
-				},
-				required: ['component'],
-				additionalProperties: false
-			},
-			minItems: 1
-		}
+				additionalProperties: true
+			}
+		},
+		required: ['component'],
+		additionalProperties: false
 	},
-	minProperties: 1,
-	additionalProperties: false
+	minItems: 1
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -17,8 +17,7 @@ sections:
       options:
         path: /service/namespace/new
   topComponents:
-    components:
-      - component: TestComponent
+    - component: TestComponent
   fieldsGroup:
   - name: detail
     position: left
@@ -75,15 +74,14 @@ sections:
 - name: semaphoreBrowse
   rootComponent: BrowseSection
   topComponents:
-    components:
-      - component: TestComponent
-        attributes:
-          name: test
-          sarasa: test23
-      - component: TestComponent2
-        attributes:
-          name: test
-          sarasa: test23
+    - component: TestComponent
+      attributes:
+        name: test
+        sarasa: test23
+    - component: TestComponent2
+      attributes:
+        name: test
+        sarasa: test23
   source:
     service: sac
     namespace: claim-semaphore

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -23,13 +23,11 @@
                     }
                 }
             ],
-            "topComponents": {
-                "components": [
-                    {
-                        "component": "TestComponent"
-                    }
-                ]
-            },
+            "topComponents": [
+                {
+                    "component": "TestComponent"
+                }
+            ],
             "fieldsGroup": [
                 {
                     "name": "detail",
@@ -162,24 +160,22 @@
                 "method": "browse",
                 "resolve": false
             },
-            "topComponents": {
-                "components": [
-                    {
-                        "component": "TestComponent",
-                        "attributes": {
-                            "name": "test",
-                            "sarasa": "test23"
-                        }
-                    },
-                    {
-                        "component": "TestComponent2",
-                        "attributes": {
-                            "name": "test",
-                            "sarasa": "test23"
-                        }
+            "topComponents": [
+                {
+                    "component": "TestComponent",
+                    "attributes": {
+                        "name": "test",
+                        "sarasa": "test23"
                     }
-                ]
-            },
+                },
+                {
+                    "component": "TestComponent2",
+                    "attributes": {
+                        "name": "test",
+                        "sarasa": "test23"
+                    }
+                }
+            ],
             "fields": [
                 {
                     "name": "id",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-583

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe validar un nuevo campo topComponents dentro de todos los EditSections, el cual es un Array con Objetos que reciban las siguientes props:
- 
- component: nombres del componente.
- 
- attributes: objeto opcional libre de atributos

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego la el schema pra topComponents con sus respectivas properties y se lo agrego a las properties custom de las sections de edit y new

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README