### PR TITLE
JMV-625 add static filters

### DIFF
--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -2,13 +2,13 @@
 
 const { properties, required } = require('../common/base');
 const actions = require('../common/actions');
-const browseBase = require('../common/browseBase');
+const getBrowseBaseSchema = require('../common/browseBase');
 
 module.exports = {
 	type: 'object',
 	properties: {
 		...properties,
-		...browseBase,
+		...getBrowseBaseSchema(true),
 		root: { const: 'Browse' },
 		actions
 	},

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -3,16 +3,49 @@
 const PAGE_SIZES = [15, 30, 60, 100];
 const DEFAULT_PAGE_SIZE = 60;
 
-module.exports = {
-	fields: {
-		type: 'array',
-		items: {
-			$ref: 'schemaDefinitions#/definitions/browseField'
+
+const getBrowseBaseSchema = (isPage = false) => {
+	const getStaticFiltersValue = () => {
+		const dinamicProps = !isPage ? { dinamic: {	type: 'string' } } : {};
+
+		return {
+			...dinamicProps,
+			static: { type: 'string' }
+		};
+	};
+
+	return {
+		fields: {
+			type: 'array',
+			items: {
+				$ref: 'schemaDefinitions#/definitions/browseField'
+			},
+			minItems: 1
 		},
-		minItems: 1
-	},
-	hasPreview: { type: 'boolean', default: false },
-	canEdit: { type: 'boolean', default: true },
-	canView: { type: 'boolean', default: false },
-	pageSize: { enum: PAGE_SIZES, default: DEFAULT_PAGE_SIZE }
+		staticFilters: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					name: { type: 'string' },
+					target: { enum: ['path', 'query'] },
+					value: {
+						type: 'object',
+						properties: getStaticFiltersValue(),
+						additionalProperties: false,
+						minProperties: 1,
+						maxProperties: 1
+					}
+				},
+				required: ['name', 'target', 'value']
+			},
+			minItems: 1
+		},
+		hasPreview: { type: 'boolean', default: false },
+		canEdit: { type: 'boolean', default: true },
+		canView: { type: 'boolean', default: false },
+		pageSize: { enum: PAGE_SIZES, default: DEFAULT_PAGE_SIZE }
+	};
 };
+
+module.exports = getBrowseBaseSchema;

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -6,7 +6,7 @@ const DEFAULT_PAGE_SIZE = 60;
 
 const getBrowseBaseSchema = (isPage = false) => {
 	const getStaticFiltersValue = () => {
-		const dinamicProps = !isPage ? { dinamic: {	type: 'string' } } : {};
+		const dinamicProps = !isPage ? { dinamic: { type: 'string' } } : {};
 
 		return {
 			...dinamicProps,

--- a/lib/schemas/edit-new/modules/sections/browseSection.js
+++ b/lib/schemas/edit-new/modules/sections/browseSection.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browseBase = require('../../../common/browseBase');
+const getBrowseBaseSchema = require('../../../common/browseBase');
 const { browseSection } = require('../sectionsNames');
 
 module.exports = {
@@ -11,7 +11,7 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			...browseBase,
+			...getBrowseBaseSchema(),
 			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: browseSection },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -8,6 +8,13 @@
 		"method": "browse",
 		"resolve": false
 	},
+	"staticFilters": [{
+		"name": "status",
+		"target": "path",
+		"value": {
+			"static": "statusId"
+		}
+	}],
 	"fields": [{
 		"name": "id",
 		"component": "BoldText",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -89,6 +89,11 @@ sections:
     namespace: claim-semaphore
     method: browse
     resolve: false
+  staticFilters:
+    - name: status
+      target: path
+      value:
+        dinamic: statusId
   fields:
     - name: id
       component: BoldText

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -8,6 +8,15 @@
         "method": "browse",
         "resolve": false
     },
+    "staticFilters": [
+        {
+            "name": "status",
+            "target": "path",
+            "value": {
+                "static": "statusId"
+            }
+        }
+    ],
     "fields": [
         {
             "name": "id",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -8,6 +8,15 @@
         "method": "browse",
         "resolve": false
     },
+    "staticFilters": [
+        {
+            "name": "status",
+            "target": "path",
+            "value": {
+                "static": "statusId"
+            }
+        }
+    ],
     "fields": [
         {
             "name": "id",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -165,6 +165,15 @@
                 "method": "browse",
                 "resolve": false
             },
+            "staticFilters": [
+                {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                        "dinamic": "statusId"
+                    }
+                }
+            ],
             "topComponents": [
                 {
                     "component": "TestComponent",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-625

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder indicar en el schema de browse (ya sea la página o una BrowseSection), una propiedad staticFilters con la definición de filtros que se agregarán en todas las peticiones de data.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agregaron las validaciones de staicFilters en los browse de Section y en la page diferenciando sus staticFilter values

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README