### PR TITLE
add target in shema new edit

### DIFF
--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -16,6 +16,9 @@ module.exports = {
 	type: 'object',
 	properties: {
 		...properties,
+		target: {
+			$ref: 'schemaDefinitions#/definitions/endpoint'
+		},
 		root: { enum: ['Edit', 'Create'] },
 		sections: {
 			type: 'array',
@@ -29,5 +32,5 @@ module.exports = {
 		}
 	},
 	additionalProperties: false,
-	required: [...required, 'sections']
+	required: [...required, 'sections', 'target']
 };

--- a/tests/endpoint-resolver-test.js
+++ b/tests/endpoint-resolver-test.js
@@ -39,6 +39,20 @@ const mockRequest = (rejectOne = false) => {
 		});
 
 	resolveStub
+		.withArgs('claim-type', 'save')
+		.returns({
+			httpMethod: 'post',
+			url: 'http://sac.janis.localhost:3009/api/claim-type/{id}'
+		});
+
+	resolveStub
+		.withArgs('claim-type', 'get')
+		.returns({
+			httpMethod: 'get',
+			url: 'http://sac.janis.localhost:3009/api/claim-type/{id}'
+		});
+
+	resolveStub
 		.withArgs('claim-compensation', 'list')
 		.returns({
 			httpMethod: 'get',
@@ -87,9 +101,9 @@ describe('Test endpoint resolver', () => {
 		const schemaResolved = await validateSchema();
 
 		assert(resolveEndpointsSpy.calledOnce);
-		assert(addResolveDataToEndpointSpy.callCount === 4);
-		assert(callFetcherSpy.callCount === 4);
-		assert(resolveStub.callCount === 2);
+		assert(addResolveDataToEndpointSpy.callCount === 6);
+		assert(callFetcherSpy.callCount === 6);
+		assert(resolveStub.callCount === 4);
 		assert(getEndpointStub.callCount === 1);
 
 		assert.deepEqual(JSON.stringify(schemaResolved, null, 4), schemaExpectedExample.toString());
@@ -117,10 +131,10 @@ describe('Test endpoint resolver', () => {
 		await validateSchema(true);
 
 		assert(resolveEndpointsSpy.calledTwice);
-		assert(addResolveDataToEndpointSpy.callCount === 8);
-		assert(resolveStub.callCount === 2);
+		assert(addResolveDataToEndpointSpy.callCount === 12);
+		assert(resolveStub.callCount === 4);
 		assert(getEndpointStub.callCount === 1);
-		assert(callFetcherSpy.callCount === 8);
+		assert(callFetcherSpy.callCount === 12);
 	});
 
 });

--- a/tests/mocks/schemas/edit-with-sources.yml
+++ b/tests/mocks/schemas/edit-with-sources.yml
@@ -4,8 +4,11 @@ root: Edit
 source:
   service: sac
   namespace: claim-type
-  method: edit
-  resolve: false
+  method: get
+target:
+  service: sac
+  namespace: claim-type
+  method: save
 sections:
 - name: mainFormSection
   rootComponent: MainForm

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -4,7 +4,12 @@ root: Edit
 source:
   service: sac
   namespace: claim-motive
-  method: edit
+  method: get
+  resolve: false
+target:
+  service: sac
+  namespace: claim-motive
+  method: save
   resolve: false
 sections:
 - name: mainFormSection

--- a/tests/mocks/schemas/expected/edit-with-sources.json
+++ b/tests/mocks/schemas/expected/edit-with-sources.json
@@ -5,8 +5,18 @@
     "source": {
         "service": "sac",
         "namespace": "claim-type",
-        "method": "edit",
-        "resolve": false
+        "method": "get",
+        "resolve": true,
+        "httpMethod": "get",
+        "url": "http://sac.janis.localhost:3009/api/claim-type/{id}"
+    },
+    "target": {
+        "service": "sac",
+        "namespace": "claim-type",
+        "method": "save",
+        "resolve": true,
+        "httpMethod": "post",
+        "url": "http://sac.janis.localhost:3009/api/claim-type/{id}"
     },
     "sections": [
         {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -5,7 +5,13 @@
     "source": {
         "service": "sac",
         "namespace": "claim-motive",
-        "method": "edit",
+        "method": "get",
+        "resolve": false
+    },
+    "target": {
+        "service": "sac",
+        "namespace": "claim-motive",
+        "method": "save",
         "resolve": false
     },
     "sections": [

--- a/tests/mocks/schemas/new.yml
+++ b/tests/mocks/schemas/new.yml
@@ -5,7 +5,10 @@ source:
   service: sac
   namespace: claim-motive
   method: new
-  resolve: false
+target:
+  service: sac
+  namespace: claim-motive
+  method: save
 sections:
 - name: mainFormSection
   rootComponent: MainForm


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-625

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder indicar la propiedad target en los schemas, y debe ser un endpoint válido (service, namespace y method)

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego al schema de edit new una nueva propiedad "target" tipo endpoint requerido

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README