### PR TITLE
add types in static filters

### DIFF
--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -10,7 +10,14 @@ const getBrowseBaseSchema = (isPage = false) => {
 
 		return {
 			...dinamicProps,
-			static: { type: 'string' }
+			static: {
+				anyOf: [
+					{ type: 'string' },
+					{ type: 'number' },
+					{ type: 'array' },
+					{ type: 'object' }
+				]
+			}
 		};
 	};
 

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -8,13 +8,22 @@
 		"method": "browse",
 		"resolve": false
 	},
-	"staticFilters": [{
-		"name": "status",
-		"target": "path",
-		"value": {
-			"static": "statusId"
+	"staticFilters": [
+		{
+			"name": "status",
+			"target": "path",
+			"value": {
+				"static": "statusId"
+			}
+		},
+		{
+			"name": "status",
+			"target": "path",
+			"value": {
+				"static": [2, 4]
+			}
 		}
-	}],
+	],
 	"fields": [{
 		"name": "id",
 		"component": "BoldText",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -99,6 +99,15 @@ sections:
       target: path
       value:
         dinamic: statusId
+    - name: status
+      target: query
+      value:
+        static: 1
+    - name: status
+      target: query
+      value:
+        static:
+          id: "string"
   fields:
     - name: id
       component: BoldText

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -15,6 +15,13 @@
             "value": {
                 "static": "statusId"
             }
+        },
+        {
+            "name": "status",
+            "target": "path",
+            "value": {
+				"static": [2, 4]
+            }
         }
     ],
     "fields": [

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -15,6 +15,13 @@
             "value": {
                 "static": "statusId"
             }
+        },
+        {
+            "name": "status",
+            "target": "path",
+            "value": {
+                "static": [2, 4]
+            }
         }
     ],
     "fields": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -178,6 +178,22 @@
                     "value": {
                         "dinamic": "statusId"
                     }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": 1
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": {
+                            "id": "string"
+                        }
+                    }
                 }
             ],
             "topComponents": [


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-625

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder indicar en el schema de browse (ya sea la página o una BrowseSection), una propiedad staticFilters con la definición de filtros que se agregarán en todas las peticiones de data.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agregaron las validaciones de staicFilters en los browse de Section y en la page diferenciando sus staticFilter values. Se agregaron mas tipos para el filtro con value static

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README