### PR TITLE
JMV-629 add env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ validate     Validate if the file or files are valid schemas
 --input, -i   write a relative dir folder or dir file
 --output, -o  write a relative dir fordel for your outputs
 --service, -s write a service local for resolve endpoints
+--env, -e     write a current environment for resolve endpoints
 ```
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -23,6 +23,12 @@ const { argv } = require('yargs')
 		type: 'string',
 		describe: 'write a service local for resolve endpoints'
 	})
+	.option('env', {
+		alias: 'e',
+		type: 'string',
+		describe: 'write a current environment',
+		default: 'local'
+	})
 	.option('minified', {
 		alias: 'm',
 		type: 'boolean',
@@ -38,13 +44,14 @@ const ViewSchemaValidator = require('./lib');
 		input,
 		output,
 		minified,
+		env,
 		service,
 		_: commands
 	} = argv;
 
 	const [command] = commands;
 
-	const schemaValidator = new ViewSchemaValidator(input, output, service, minified, command);
+	const schemaValidator = new ViewSchemaValidator(input, output, service, minified, command, env);
 	const execute = schemaValidator.execute.bind(schemaValidator);
 
 	try {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -9,7 +9,7 @@ const EndpointResolver = require('./endpoint-resolver');
 
 
 class Builder {
-	constructor(input, output, service, minified) {
+	constructor(input, output, service, minified, env) {
 		this.input = input;
 		this.output = output;
 		this.service = service;
@@ -17,7 +17,7 @@ class Builder {
 		this.inputPath = path.join(process.cwd(), input);
 		this.outputPath = output && path.join(process.cwd(), output);
 
-		this.endpointResolver = new EndpointResolver(service);
+		this.endpointResolver = new EndpointResolver(service, env);
 		this.endpointResolver.execute.bind(this.endpointResolver);
 	}
 

--- a/lib/endpoint-resolver.js
+++ b/lib/endpoint-resolver.js
@@ -12,9 +12,10 @@ const ajv = new Ajv();
 const routerFetcher = new RouterFetcher();
 
 class EndpointResolver {
-	constructor(service) {
+	constructor(service, env) {
 		this.service = service;
-		this.endpointResolverLocal = new EndpointResolverLocal('schemas/public.json');
+
+		this.endpointResolverLocal = new EndpointResolverLocal('schemas/public.json', env);
 		this.requestCache = {};
 	}
 

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -6,10 +6,10 @@ const DEFAULT_PAGE_SIZE = 60;
 
 const getBrowseBaseSchema = (isPage = false) => {
 	const getStaticFiltersValue = () => {
-		const dinamicProps = !isPage ? { dinamic: { type: 'string' } } : {};
+		const dynamicProps = !isPage ? { dynamic: { type: 'string' } } : {};
 
 		return {
-			...dinamicProps,
+			...dynamicProps,
 			static: { type: 'string' }
 		};
 	};

--- a/lib/view-schema-validator.js
+++ b/lib/view-schema-validator.js
@@ -3,12 +3,13 @@
 const Builder = require('./builder');
 
 class ViewSchemaValidator {
-	constructor(input, output, service, minified, command) {
+	constructor(input, output, service, minified, command, env) {
 		this.command = command;
 		this.input = input;
 		this.minified = minified;
 		this.output = output;
 		this.service = service;
+		this.env = env;
 	}
 
 	/**
@@ -18,7 +19,14 @@ class ViewSchemaValidator {
 	 * @return {<Promise>}
 	 */
 	executeBuilder(build) {
-		const builder = new Builder(this.input, this.output, this.service, this.minified);
+		const builder = new Builder(
+			this.input,
+			this.output,
+			this.service,
+			this.minified,
+			this.env
+		);
+
 		const execute = builder.execute.bind(builder);
 		return execute(build);
 	}

--- a/tests/builder-multiple-files-test.js
+++ b/tests/builder-multiple-files-test.js
@@ -23,7 +23,8 @@ const executeInstance = (build = true) => {
 		'/tests/schemas/fakeBuildFolder',
 		undefined,
 		false,
-		build ? 'build' : 'validate'
+		build ? 'build' : 'validate',
+		'local'
 	);
 	return schemaValidator.execute.bind(schemaValidator);
 };

--- a/tests/builder-single-files-test.js
+++ b/tests/builder-single-files-test.js
@@ -21,7 +21,8 @@ const executeInstance = (build = true, file, minified = false) => {
 		'/tests/schemas/fakeBuildFolder',
 		undefined,
 		minified,
-		build ? 'build' : 'validate'
+		build ? 'build' : 'validate',
+		'local'
 	);
 	return schemaValidator.execute.bind(schemaValidator);
 };

--- a/tests/endpoint-resolver-test.js
+++ b/tests/endpoint-resolver-test.js
@@ -71,7 +71,8 @@ const validateSchema = async (twice = false) => {
 	const schemaValidatedOne = Validator.execute(schemaOne, true, '/test/data.json');
 	const schemaValidatedTwo = Validator.execute(schemaTwo, true, '/test/data.json');
 
-	const endpointResolver = new EndpointResolver('sac');
+	const endpointResolver = new EndpointResolver('sac', 'local');
+
 	endpointResolver.execute.bind(endpointResolver);
 
 	const schemaResolved = await endpointResolver.execute(schemaValidatedOne);
@@ -137,4 +138,10 @@ describe('Test endpoint resolver', () => {
 		assert(callFetcherSpy.callCount === 12);
 	});
 
+
+	it('should called EndpointResolverLocal with env beta ', () => {
+		const endpointResolver = new EndpointResolver('sac', 'beta');
+
+		assert(endpointResolver.endpointResolverLocal.environment === 'beta');
+	});
 });

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -98,7 +98,7 @@ sections:
     - name: status
       target: path
       value:
-        dinamic: statusId
+        dynamic: statusId
   fields:
     - name: id
       component: BoldText

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -176,7 +176,7 @@
                     "name": "status",
                     "target": "path",
                     "value": {
-                        "dinamic": "statusId"
+                        "dynamic": "statusId"
                     }
                 }
             ],

--- a/tests/view-schema-validator-test.js
+++ b/tests/view-schema-validator-test.js
@@ -17,7 +17,7 @@ describe('Test execute commmand initials', () => {
 	it('Should error if pass input empty string', async () => {
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 
-		const schemaValidatorOne = new ViewSchemaValidator(' ', '/build', undefined, false, 'build');
+		const schemaValidatorOne = new ViewSchemaValidator(' ', '/build', undefined, false, 'build', 'local');
 		const executeOne = schemaValidatorOne.execute.bind(schemaValidatorOne);
 
 		await assert.rejects(async () => { await executeOne(); }, { message: 'Please add input' });
@@ -27,7 +27,7 @@ describe('Test execute commmand initials', () => {
 	it('Should error if pass output empty string', async () => {
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 
-		const schemaValidatorOne = new ViewSchemaValidator('/mocks', '', undefined, false, 'build');
+		const schemaValidatorOne = new ViewSchemaValidator('/mocks', '', undefined, false, 'build', 'local');
 		const executeOne = schemaValidatorOne.execute.bind(schemaValidatorOne);
 
 		await assert.rejects(async () => { await executeOne(); }, { message: 'Please add output' });
@@ -35,7 +35,7 @@ describe('Test execute commmand initials', () => {
 
 		sandbox.restore();
 
-		const schemaValidatorTwo = new ViewSchemaValidator('/mocks', ' ', undefined, false, 'build');
+		const schemaValidatorTwo = new ViewSchemaValidator('/mocks', ' ', undefined, false, 'build', 'local');
 		const executeTwo = schemaValidatorTwo.execute.bind(schemaValidatorTwo);
 
 		await assert.rejects(async () => { await executeTwo(); }, { message: 'Please add output' });
@@ -45,7 +45,7 @@ describe('Test execute commmand initials', () => {
 	it('Should error if pass service invalid', async () => {
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 
-		const schemaValidatorOne = new ViewSchemaValidator('/mocks', '/build', ' ', false, 'build');
+		const schemaValidatorOne = new ViewSchemaValidator('/mocks', '/build', ' ', false, 'build', 'local');
 		const executeOne = schemaValidatorOne.execute.bind(schemaValidatorOne);
 
 		await assert.rejects(async () => { await executeOne(); }, { message: 'Please add valid service' });
@@ -57,7 +57,7 @@ describe('Test execute commmand initials', () => {
 
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 
-		const schemaValidatorOne = new ViewSchemaValidator('/mocks', ' ', undefined, false, 'validate');
+		const schemaValidatorOne = new ViewSchemaValidator('/mocks', ' ', undefined, false, 'validate', 'local');
 		const executeOne = schemaValidatorOne.execute.bind(schemaValidatorOne);
 
 		await executeOne();
@@ -65,7 +65,7 @@ describe('Test execute commmand initials', () => {
 		assert(execSpy.calledOnce);
 		assert(executeBuilderStub.calledOnce);
 
-		const schemaValidatorTwo = new ViewSchemaValidator('/mocks', '', undefined, false, 'validate');
+		const schemaValidatorTwo = new ViewSchemaValidator('/mocks', '', undefined, false, 'validate', 'local');
 		const executeTwo = schemaValidatorTwo.execute.bind(schemaValidatorTwo);
 
 		await executeTwo();
@@ -80,7 +80,7 @@ describe('Test execute commmand initials', () => {
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 		const builderSpy = sandbox.spy(ViewSchemaValidator.prototype, 'executeBuilder');
 
-		const schemaValidator = new ViewSchemaValidator('/test/mocks/schemas', '/test/mocks/build', undefined, false, 'validate');
+		const schemaValidator = new ViewSchemaValidator('/test/mocks/schemas', '/test/mocks/build', undefined, false, 'validate', 'local');
 
 		const execute = schemaValidator.execute.bind(schemaValidator);
 
@@ -97,7 +97,7 @@ describe('Test execute commmand initials', () => {
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 		const builderSpy = sandbox.spy(ViewSchemaValidator.prototype, 'executeBuilder');
 
-		const schemaValidator = new ViewSchemaValidator('/tests/mocks/schemas', '/tests/mocks/build', undefined, false, 'build');
+		const schemaValidator = new ViewSchemaValidator('/tests/mocks/schemas', '/tests/mocks/build', undefined, false, 'build', 'local');
 
 		const execute = schemaValidator.execute.bind(schemaValidator);
 
@@ -114,7 +114,7 @@ describe('Test execute commmand initials', () => {
 		const execSpy = sandbox.spy(ViewSchemaValidator.prototype, 'execute');
 		const builderSpy = sandbox.spy(ViewSchemaValidator.prototype, 'executeBuilder');
 
-		const schemaValidator = new ViewSchemaValidator('/tests/mocks/schemas', '/tests/mocks/build', undefined, false, 'build');
+		const schemaValidator = new ViewSchemaValidator('/tests/mocks/schemas', '/tests/mocks/build', undefined, false, 'build', 'local');
 
 		const execute = schemaValidator.execute.bind(schemaValidator);
 


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-629

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe agregar opcion al yargs y pasarle al EndpointResolver el environment correspondiente para que pueda resolver bien los endpoints.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agregó la opcion `env` en yargs y se fue pasando el valor de la opcion hacia  la instancia de EndpointResolveLocal.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README