### PR TITLE
add component link in edit and new

### DIFF
--- a/lib/schemas/edit-new/modules/components/index.js
+++ b/lib/schemas/edit-new/modules/components/index.js
@@ -5,11 +5,13 @@ const multiInput = require('./multiInput');
 const selects = require('./selects');
 const chips = require('./chips');
 const others = require('./others');
+const link = require('./link');
 
 module.exports = [
 	selects,
 	input,
 	multiInput,
+	link,
 	...chips,
 	...others
 ];

--- a/lib/schemas/edit-new/modules/components/link.js
+++ b/lib/schemas/edit-new/modules/components/link.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const { link } = require('../componentNames');
+
+module.exports = makeComponent({
+	name: link,
+	properties: {
+		translateLabels: { type: 'boolean' },
+		label: { type: 'string' },
+		labelField: { type: 'string' },
+		target: { type: 'string' }
+	}
+});

--- a/lib/schemas/edit-new/modules/components/others.js
+++ b/lib/schemas/edit-new/modules/components/others.js
@@ -7,7 +7,6 @@ const {
 	checkbox,
 	checkList,
 	color,
-	link,
 	date,
 	switch: componentSwitch,
 	text,
@@ -18,7 +17,6 @@ const {
 const components = [
 	{ name: checkbox },
 	{ name: color },
-	{ name: link },
 	{ name: date },
 	{ name: componentSwitch },
 	{ name: text },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -67,6 +67,13 @@ sections:
       component: Chip
     - name: user
       component: UserChip
+    - name: linkTest
+      component: Link
+      componentAttributes:
+        target: _blank
+        translateLabels: true
+        label: test.test.test
+        labelField: asdasd
   - name: others
     fields:
       - name: status

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -130,6 +130,16 @@
                             "name": "user",
                             "component": "UserChip",
                             "componentAttributes": {}
+                        },
+                        {
+                            "name": "linkTest",
+                            "component": "Link",
+                            "componentAttributes": {
+                                "target": "_blank",
+                                "translateLabels": true,
+                                "label": "test.test.test",
+                                "labelField": "asdasd"
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-658

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder configurar un campo con el componente Link.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego al schema de edit new una nuevo componente de Link con estas propiedades
- label (string, opcional): representa el texto que mostrará el link (valor fijo)
- labelField (string, opcional): representa el nombre del campo de la data que contiene el texto del link
- translateLabels (boolean, opcional): indica si el texto del link es una key de traducción y debe ser procesada.
- target(string, opcional): indica dónde se debe abrir el link al clickear

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README