### PR TITLE
Jmv 686 fields array component

### DIFF
--- a/lib/schemas/edit-new/modules/componentNames.js
+++ b/lib/schemas/edit-new/modules/componentNames.js
@@ -15,5 +15,6 @@ module.exports = {
 	chip: 'Chip',
 	userChip: 'UserChip',
 	code: 'Code',
-	dateTimePicker: 'DateTimePicker'
+	dateTimePicker: 'DateTimePicker',
+	fieldsArray: 'FieldsArray'
 };

--- a/lib/schemas/edit-new/modules/components/fieldsArray.js
+++ b/lib/schemas/edit-new/modules/components/fieldsArray.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const { fieldsArray } = require('../componentNames');
+
+module.exports = makeComponent({
+	name: fieldsArray,
+	properties: {
+		fields: {
+			type: 'array',
+			items: {
+				$ref: 'schemaDefinitions#/definitions/editNewField'
+			},
+			minItems: 1
+		},
+		canChangeElements: { type: 'boolean' },
+		minElements: { type: 'number' }
+	},
+	requiredProperties: ['fields']
+});

--- a/lib/schemas/edit-new/modules/components/index.js
+++ b/lib/schemas/edit-new/modules/components/index.js
@@ -8,6 +8,7 @@ const code = require('./code');
 const dateTimePicker = require('./dateTimePicker');
 const others = require('./others');
 const link = require('./link');
+const fieldsArray = require('./fieldsArray');
 
 module.exports = [
 	selects,
@@ -16,6 +17,7 @@ module.exports = [
 	code,
 	link,
 	dateTimePicker,
+	fieldsArray,
 	...chips,
 	...others
 ];

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -82,6 +82,14 @@ sections:
         translateLabels: true
         label: test.test.test
         labelField: asdasd
+    - name: fieldsArray
+      component: FieldsArray
+      componentAttributes:
+        canChangeElements: true
+        minElements: 1
+        fields:
+          - name: test
+            component: Text
   - name: others
     fields:
       - name: status

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -157,6 +157,21 @@
                                 "label": "test.test.test",
                                 "labelField": "asdasd"
                             }
+                        },
+                        {
+                            "name": "fieldsArray",
+                            "component": "FieldsArray",
+                            "componentAttributes": {
+                                "canChangeElements": true,
+                                "minElements": 1,
+                                "fields": [
+                                    {
+                                        "name": "test",
+                                        "component": "Text",
+                                        "componentAttributes": {}
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-686

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder indicar un nuevo componente FieldsArray en formularios. Debe aceptar los siguientes component attributes:

- fields: Un array de Fields. Requerido, al menos un elemento.
- canChangeElements: boolean. Opcional, sin defaults.
- minElements: number. Opcional, sin defaults.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego un nuevo componente FieldsArray en edit y new. Con las properties descriptas arriba.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README