### PR TITLE
JMV-691 add properties in user chip

### DIFF
--- a/lib/schemas/browse/modules/components/chips.js
+++ b/lib/schemas/browse/modules/components/chips.js
@@ -16,7 +16,20 @@ const chipComponents = [
 		name: timeChip
 	},
 	{
-		name: userChip
+		name: userChip,
+		properties: {
+			userDataSource: {
+				type: 'object',
+				properties: {
+					firstname: { type: 'string' },
+					lastname: { type: 'string' },
+					email: { type: 'string' },
+					images: { type: 'string' }
+				},
+				additionalProperties: false,
+				required: ['firstname', 'lastname', 'email', 'images']
+			}
+		}
 	},
 	{
 		name: chip,

--- a/lib/schemas/edit-new/modules/components/chips.js
+++ b/lib/schemas/edit-new/modules/components/chips.js
@@ -7,7 +7,20 @@ const { chip, userChip } = componentNames;
 
 const chipComponents = [
 	{
-		name: userChip
+		name: userChip,
+		properties: {
+			userDataSource: {
+				type: 'object',
+				properties: {
+					firstname: { type: 'string' },
+					lastname: { type: 'string' },
+					email: { type: 'string' },
+					images: { type: 'string' }
+				},
+				additionalProperties: false,
+				required: ['firstname', 'lastname', 'email', 'images']
+			}
+		}
 	},
 	{
 		name: chip,

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -51,8 +51,19 @@
 			}
 		}
 	}, {
-		"name": "user",
+		"name": "user1",
 		"component": "UserChip"
+	}, {
+		"name": "user2",
+		"component": "UserChip",
+		"componentAttributes": {
+			"userDataSource": {
+				"email": "email",
+				"firstname": "firstname",
+				"lastname": "lastname",
+				"images": "images"
+			}
+		}
 	}, {
 		"name": "name",
 		"component": "LightText",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -65,8 +65,16 @@ sections:
         - - name: required
     - name: test
       component: Chip
-    - name: user
+    - name: user1
       component: UserChip
+    - name: user2
+      component: UserChip
+      componentAttributes:
+        userDataSource:
+          email: email
+          firstname: firstname
+          lastname: lastname
+          images: images
     - name: color
       component: ColorPicker
     - name: exampleCode

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -91,7 +91,7 @@
             }
         },
         {
-            "name": "user",
+            "name": "user1",
             "component": "UserChip",
             "attributes": {
                 "isStatus": false,
@@ -100,6 +100,24 @@
                 "initialSortDirection": "desc"
             },
             "componentAttributes": {}
+        },
+        {
+            "name": "user2",
+            "component": "UserChip",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+    			"userDataSource": {
+                    "email": "email",
+                    "firstname": "firstname",
+                    "lastname": "lastname",
+                    "images": "images"
+                }
+            }
         },
         {
             "name": "name",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -91,7 +91,7 @@
             }
         },
         {
-            "name": "user",
+            "name": "user1",
             "component": "UserChip",
             "attributes": {
                 "isStatus": false,
@@ -100,6 +100,24 @@
                 "initialSortDirection": "desc"
             },
             "componentAttributes": {}
+        },
+        {
+            "name": "user2",
+            "component": "UserChip",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+    			"userDataSource": {
+                    "email": "email",
+                    "firstname": "firstname",
+                    "lastname": "lastname",
+                    "images": "images"
+                }
+            }
         },
         {
             "name": "name",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -127,9 +127,21 @@
                             }
                         },
                         {
-                            "name": "user",
+                            "name": "user1",
                             "component": "UserChip",
                             "componentAttributes": {}
+                        },
+                        {
+                            "name": "user2",
+                            "component": "UserChip",
+                            "componentAttributes": {
+                                "userDataSource": {
+                                    "email": "email",
+                                    "firstname": "firstname",
+                                    "lastname": "lastname",
+                                    "images": "images"
+                                }
+                            }
                         },
                         {
                             "name": "color",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-691

DESCRIPCIÓN DEL REQUERIMIENTO

Los campos que tengan el componente UserChip, deben poder aceptar el siguiente component attribute:

- userDataSource: un objeto opcional, que en caso de estar definido, debe tener 4 propiedades obligatorias: firstname, lastname, email e images, de tipo string.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego al componente de userChip de de los browses y los formularios nuevos componentAttributes.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README