### PR TITLE
Jmv 702 header edit new properties

### DIFF
--- a/lib/schemas/edit-new/modules/headerProperties.js
+++ b/lib/schemas/edit-new/modules/headerProperties.js
@@ -1,13 +1,21 @@
 'use strict';
 
+const components = require('../../browse/modules/components');
+const { badgeLetter, statusChip } = require('../../browse/modules/componentNames');
+
 const commonAfterBefore = {
 	type: 'array',
 	items: {
 		type: 'object',
 		properties: {
 			name: { type: 'string' },
-			component: { enum: ['BadgeLetter', 'StatusChip'] }
+			component: { enum: [badgeLetter, statusChip] },
+			componentAttributes: {
+				type: 'object',
+				default: {}
+			}
 		},
+		allOf: components,
 		minItems: 1
 	}
 };

--- a/lib/schemas/edit-new/modules/headerProperties.js
+++ b/lib/schemas/edit-new/modules/headerProperties.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const commonAfterBefore = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			name: { type: 'string' },
+			component: { enum: ['BadgeLetter', 'StatusChip'] }
+		},
+		minItems: 1
+	}
+};
+
+module.exports = {
+	type: 'object',
+	properties: {
+		title: {
+			type: 'object',
+			properties: {
+				afterId: commonAfterBefore,
+				beforeId: commonAfterBefore
+			},
+			minProperties: 1,
+			additionalProperties: false
+		}
+	},
+	minProperties: 1,
+	additionalProperties: false
+};

--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -5,6 +5,7 @@ const sections = require('./modules/sections');
 const sectionNames = require('./modules/sectionsNames');
 const { makeSection } = require('../../schemas/utils');
 const commonSectionProperties = require('./modules/sections/commonProperties');
+const header = require('./modules/headerProperties');
 
 const sectionsModified = sections.map(section => (
 	makeSection(section, {
@@ -20,6 +21,7 @@ module.exports = {
 			$ref: 'schemaDefinitions#/definitions/endpoint'
 		},
 		root: { enum: ['Edit', 'Create'] },
+		header,
 		sections: {
 			type: 'array',
 			items: {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -19,6 +19,8 @@ header:
     afterId:
       - name: test
         component: StatusChip
+        componentAttributes:
+          useTheme: true
 sections:
 - name: mainFormSection
   rootComponent: MainForm

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -11,6 +11,14 @@ target:
   namespace: claim-motive
   method: save
   resolve: false
+header:
+  title:
+    beforeId:
+      - name: test
+        component: BadgeLetter
+    afterId:
+      - name: test
+        component: StatusChip
 sections:
 - name: mainFormSection
   rootComponent: MainForm

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -19,13 +19,19 @@
           "beforeId": [
             {
               "name": "test",
-              "component": "BadgeLetter"
+              "component": "BadgeLetter",
+              "componentAttributes": {
+                "translateLabels": true
+              }
             }
           ],
           "afterId": [
             {
               "name": "test",
-              "component": "StatusChip"
+              "component": "StatusChip",
+              "componentAttributes": {
+                "useTheme": true
+              }
             }
           ]
         }

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -14,6 +14,22 @@
         "method": "save",
         "resolve": false
     },
+    "header": {
+        "title": {
+          "beforeId": [
+            {
+              "name": "test",
+              "component": "BadgeLetter"
+            }
+          ],
+          "afterId": [
+            {
+              "name": "test",
+              "component": "StatusChip"
+            }
+          ]
+        }
+    },
     "sections": [
         {
             "name": "mainFormSection",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-702

DESCRIPCIÓN DEL REQUERIMIENTO

Se deben poder definir las siguientes propiedades del schema para customizar el header en Edits:

- header.title.beforeId: Opcional, array de objetos con las siguientes propiedades:
- - name: String, requerido.
- - component: String, requerido. Enum de Componentes que puedan ser ubicados en el header. Al momento, deben ser BadgeLetter y StatusChip.
- header.title.afterId: Exactamente igual que beforeId.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego al schema default de edit new nuevas properties para agregar componentes en el edit. Con Componentes de listado y sus respectivos componentAttributes.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README