### PR TITLE
JMV-689 add callback in actionButtons

### DIFF
--- a/lib/schemas/browse/modules/components/actionButtons.js
+++ b/lib/schemas/browse/modules/components/actionButtons.js
@@ -6,7 +6,7 @@ const action = require('../../../common/actions/action');
 
 const availableCallbacks = ['removeRow', 'refresh'];
 
-const customActions = {
+const customAction = {
 	...action,
 	properties: {
 		...action.properties,
@@ -21,7 +21,7 @@ module.exports = makeComponent({
 	properties: {
 		actionsData: {
 			type: 'array',
-			items: customActions,
+			items: customAction,
 			minItems: 1
 		}
 	},

--- a/lib/schemas/browse/modules/components/actionButtons.js
+++ b/lib/schemas/browse/modules/components/actionButtons.js
@@ -4,12 +4,24 @@ const { makeComponent } = require('../../../utils');
 const { actionButtons } = require('../componentNames');
 const action = require('../../../common/actions/action');
 
+const availableCallbacks = ['removeRow', 'refresh'];
+
+const customActions = {
+	...action,
+	properties: {
+		...action.properties,
+		callback: {
+			enum: availableCallbacks
+		}
+	}
+};
+
 module.exports = makeComponent({
 	name: actionButtons,
 	properties: {
 		actionsData: {
 			type: 'array',
-			items: action,
+			items: customActions,
 			minItems: 1
 		}
 	},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -145,5 +145,22 @@
 				]
 			}
 		}
+	}, {
+		"name": "actions",
+		"component": "ActionButtons",
+		"componentAttributes": {
+			"actionsData": [
+				{
+					"name": "new",
+					"icon": "star_light",
+					"color": "fizzGreen",
+					"type": "link",
+					"options": {
+						"path": "/sac/claim-type/new"
+					},
+					"callback": "removeRow"
+				}
+			]
+		}
 	}]
 }

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -261,6 +261,30 @@
                 "type": "equal",
                 "remote": false
             }
+        },
+        {
+            "name": "actions",
+            "component": "ActionButtons",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "actionsData": [
+                    {
+                        "name": "new",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "link",
+                        "options": {
+                            "path": "/sac/claim-type/new"
+                        },
+                        "callback": "removeRow"
+                    }
+                ]
+            }
         }
     ],
     "hasPreview": false,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -261,6 +261,30 @@
                 "type": "equal",
                 "remote": false
             }
+        },
+        {
+            "name": "actions",
+            "component": "ActionButtons",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "actionsData": [
+                    {
+                        "name": "new",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "link",
+                        "options": {
+                            "path": "/sac/claim-type/new"
+                        },
+                        "callback": "removeRow"
+                    }
+                ]
+            }
         }
     ],
     "hasPreview": false,


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-689

DESCRIPCIÓN DEL REQUERIMIENTO

Para los fields que usen el componente ActionButtons, cada acción debe aceptar un nuevo component attribute callback que sea un string, opcional. Debe ser un enum de: removeRow y refresh.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego al componente de ActionButtons una la property `callback` con un enum de valores en las actions de esta.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README