### PR TITLE
JMV-724 add apikeys section

### DIFF
--- a/lib/schemas/edit-new/modules/sections/apiKeysSection.js
+++ b/lib/schemas/edit-new/modules/sections/apiKeysSection.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { apiKeysSection } = require('../sectionsNames');
+
+module.exports = {
+	if: {
+		properties: {
+			rootComponent: { const: apiKeysSection }
+		}
+	},
+	then: {
+		properties: {
+			title: { type: 'string' },
+			name: { type: 'string' },
+			rootComponent: { type: 'string', const: apiKeysSection },
+			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			createEndpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			deleteEndpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			parentIdField: { type: 'string' }
+		},
+		required: ['name', 'rootComponent', 'source', 'createEndpoint', 'deleteEndpoint', 'parentIdField'],
+		additionalProperties: false
+	}
+};

--- a/lib/schemas/edit-new/modules/sections/index.js
+++ b/lib/schemas/edit-new/modules/sections/index.js
@@ -5,11 +5,13 @@ const BrowseSection = require('./browseSection');
 const LogsBrowseSection = require('./logsBrowseSection');
 const FilesSection = require('./filesSection');
 const OrderItemsSection = require('./orderItemsSection');
+const ApiKeysSection = require('./apiKeysSection');
 
 module.exports = [
 	MainForm,
 	BrowseSection,
 	LogsBrowseSection,
 	FilesSection,
-	OrderItemsSection
+	OrderItemsSection,
+	ApiKeysSection
 ];

--- a/lib/schemas/edit-new/modules/sectionsNames.js
+++ b/lib/schemas/edit-new/modules/sectionsNames.js
@@ -5,5 +5,6 @@ module.exports = {
 	browseSection: 'BrowseSection',
 	logsBrowseSection: 'LogsBrowseSection',
 	filesSection: 'FilesSection',
-	orderItemsSection: 'OrderItemsSection'
+	orderItemsSection: 'OrderItemsSection',
+	apiKeysSection: 'ApiKeysSection'
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -229,3 +229,21 @@ sections:
   rootComponent: FilesSection
 - name: orderItemsSection
   rootComponent: OrderItemsSection
+- name: apiKeysSection
+  rootComponent: ApiKeysSection
+  parentIdField: user
+  source:
+    service: id
+    namespace: user
+    method: list-api-keys
+    resolve: false
+  createEndpoint:
+    service: id
+    namespace: user
+    method: create-api-key
+    resolve: false
+  deleteEndpoint:
+    service: id
+    namespace: user
+    method: delete-api-key
+    resolve: false

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -499,6 +499,29 @@
         {
             "name": "orderItemsSection",
             "rootComponent": "OrderItemsSection"
-        }
+        },
+        {
+            "name": "apiKeysSection",
+            "rootComponent": "ApiKeysSection",
+            "parentIdField": "user",
+            "source": {
+              "service": "id",
+              "namespace": "user",
+              "method": "list-api-keys",
+              "resolve": false
+            },
+            "createEndpoint": {
+              "service": "id",
+              "namespace": "user",
+              "method": "create-api-key",
+              "resolve": false
+            },
+            "deleteEndpoint": {
+              "service": "id",
+              "namespace": "user",
+              "method": "delete-api-key",
+              "resolve": false
+            }
+          }
     ]
 }


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-724

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe validar el rootComponent de una sección de edit con el nombre ApiKeysSection
Debe aceptar las siguientes propiedades:
- source: Tipo endpoint. Requerido.
- createEndpoint Tipo endpoint. Requerido.
- deleteEndpoint Tipo endpoint. Requerido.
- parentIdField: Tipo string. Requerido. // Este campo es para poder asociar la API Key a el registro padre (puede ser un usuario, un servicio, o algún otro en el futuro.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego a las secciones de edit una nueva sección con las properties descriptas arriba.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README