### PR TITLE
add position propertie in topComponents

### DIFF
--- a/lib/schemas/edit-new/modules/sections/commonProperties.js
+++ b/lib/schemas/edit-new/modules/sections/commonProperties.js
@@ -1,9 +1,7 @@
 'use strict';
 
-const actions = require('../../../common/actions');
 const topComponents = require('./components/topComponents');
 
 module.exports = {
-	actions,
 	topComponents
 };

--- a/lib/schemas/edit-new/modules/sections/components/topComponents.js
+++ b/lib/schemas/edit-new/modules/sections/components/topComponents.js
@@ -6,6 +6,10 @@ module.exports = {
 		type: 'object',
 		properties: {
 			component: { type: 'string' },
+			position: {
+				type: 'string',
+				enum: ['left', 'right']
+			},
 			attributes: {
 				type: 'object',
 				additionalProperties: true

--- a/lib/schemas/edit-new/modules/sections/components/topComponents.js
+++ b/lib/schemas/edit-new/modules/sections/components/topComponents.js
@@ -1,22 +1,42 @@
 'use strict';
 
+const actions = require('../../../../common/actions');
+
+const commonProperties = {
+	position: {
+		type: 'string',
+		enum: ['left', 'right']
+	},
+	attributes: {
+		type: 'object',
+		additionalProperties: true
+	}
+};
+
 module.exports = {
 	type: 'array',
 	items: {
 		type: 'object',
-		properties: {
-			component: { type: 'string' },
-			position: {
-				type: 'string',
-				enum: ['left', 'right']
-			},
-			attributes: {
-				type: 'object',
-				additionalProperties: true
+		if: {
+			properties: {
+				component: { const: 'ActionButtons' }
 			}
 		},
-		required: ['component'],
-		additionalProperties: false
+		then: {
+			properties: {
+				actions,
+				...commonProperties
+			},
+			required: ['actions', 'component']
+		},
+		else: {
+			properties: {
+				component: { type: 'string' },
+				...commonProperties
+			},
+			required: ['component'],
+			additionalProperties: false
+		}
 	},
 	minItems: 1
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -33,6 +33,10 @@ sections:
         path: /service/namespace/new
   topComponents:
     - component: TestComponent
+    - component: TestComponentLeft
+      position: left
+    - component: TestComponentRight
+      position: right
   fieldsGroup:
   - name: detail
     position: left

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -24,19 +24,21 @@ header:
 sections:
 - name: mainFormSection
   rootComponent: MainForm
-  actions:
-    - name: new
-      icon: star_light
-      color: fizzGreen
-      type: link
-      options:
-        path: /service/namespace/new
   topComponents:
     - component: TestComponent
     - component: TestComponentLeft
       position: left
     - component: TestComponentRight
       position: right
+    - component: ActionButtons
+      position: right
+      actions:
+        - name: new
+          icon: star_light
+          color: fizzGreen
+          type: link
+          options:
+            path: /service/namespace/new
   fieldsGroup:
   - name: detail
     position: left

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -54,6 +54,14 @@
             "topComponents": [
                 {
                     "component": "TestComponent"
+                },
+                {
+                    "component": "TestComponentLeft",
+                    "position": "left"
+                },
+                {
+                    "component": "TestComponentRight",
+                    "position": "right"
                 }
             ],
             "fieldsGroup": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -40,17 +40,6 @@
         {
             "name": "mainFormSection",
             "rootComponent": "MainForm",
-            "actions": [
-                {
-                    "name": "new",
-                    "icon": "star_light",
-                    "color": "fizzGreen",
-                    "type": "link",
-                    "options": {
-                        "path": "/service/namespace/new"
-                    }
-                }
-            ],
             "topComponents": [
                 {
                     "component": "TestComponent"
@@ -62,6 +51,21 @@
                 {
                     "component": "TestComponentRight",
                     "position": "right"
+                },
+                {
+                    "component": "ActionButtons",
+                    "position": "right",
+                    "actions": [
+                        {
+                            "name": "new",
+                            "icon": "star_light",
+                            "color": "fizzGreen",
+                            "type": "link",
+                            "options": {
+                                "path": "/service/namespace/new"
+                            }
+                        }
+                    ]
                 }
             ],
             "fieldsGroup": [


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-789

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder declarar position a un topComponent.
Agregar actions a topComponents.

DESCRIPCIÓN DE LA SOLUCIÓN
Se agrego al schema de topComponent una nueva prop de position que sea un enum de left y right, opcional. Se agrego actions a topComponents con sus respectivas validaciones

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README