### PR TITLE
add prefix mapper

### DIFF
--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -58,6 +58,28 @@ const Mapper = {
 			if: {
 				type: 'object',
 				properties: {
+					name: { const: 'prefix' }
+				}
+			},
+			then: {
+				properties: {
+					name: { const: 'prefix' },
+					props: {
+						type: 'object',
+						properties: {
+							value: {
+								type: 'string'
+							}
+						},
+						additionalProperties: false
+					}
+				}
+			}
+		},
+		{
+			if: {
+				type: 'object',
+				properties: {
 					name: { enum: MAPPERS }
 				}
 			},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -57,7 +57,17 @@
                     "format": "DD/MM/YYYY"
                 }
             }
-		},
+        },
+        {
+            "name": "nameTest",
+            "component": "Text",
+            "mapper": {
+                "name": "prefix",
+                "props": {
+                    "value": "common.names."
+                }
+            }
+        },
 		{
             "name": "linkTest",
             "component": "Link"

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -91,6 +91,25 @@
             }
         },
         {
+            "name": "nameTest",
+            "component": "Text",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "mapper": {
+                "name": "prefix",
+                "props": {
+                    "value": "common.names."
+                }
+            },
+            "componentAttributes": {
+                "fontWeight": "normal"
+            }
+        },
+        {
             "name": "linkTest",
             "component": "Link",
             "attributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -91,6 +91,25 @@
             }
         },
         {
+            "name": "nameTest",
+            "component": "Text",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "mapper": {
+                "name": "prefix",
+                "props": {
+                    "value": "common.names."
+                }
+            },
+            "componentAttributes": {
+                "fontWeight": "normal"
+            }
+        },
+        {
             "name": "linkTest",
             "component": "Link",
             "attributes": {


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-813

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder declarar un nuevo mapper para definir un prefijo para traducciones.

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego a los mappers un nuevo mapper llamado prefix con una prop value para definir el prefijo

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README