### PR TITLE
add validation in select remote browse

### DIFF
--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -7,22 +7,46 @@ module.exports = makeComponent({
 	properties: {
 		translateLabels: { type: 'boolean', default: true },
 		options: {
-			type: 'array',
-			items: {
-				type: 'object',
-				properties: {
-					label: { type: 'string' },
-					value: {
-						anyOf: [
-							{ type: 'number' },
-							{ type: 'string' },
-							{ type: 'boolean' }
-						]
+			oneOf: [
+				{
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							label: { type: 'string' },
+							value: {
+								anyOf: [
+									{ type: 'number' },
+									{ type: 'string' },
+									{ type: 'boolean' }
+								]
+							}
+						},
+						additionalProperties: false,
+						required: ['label', 'value']
 					}
 				},
-				additionalProperties: false,
-				required: ['label', 'value']
-			}
+				{
+					type: 'object',
+					properties: {
+						endpoint: {
+							$ref: 'schemaDefinitions#/definitions/endpoint'
+						},
+						searchParam: { type: 'string', default: 'term' },
+						valuesMapper: {
+							type: 'object',
+							properties: {
+								label: { type: 'string' },
+								value: { type: 'string' }
+							},
+							required: ['label', 'value'],
+							additionalProperties: false
+						}
+					},
+					required: ['endpoint', 'valuesMapper'],
+					additionalProperties: false
+				}
+			]
 		}
 	}
 });

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -130,6 +130,31 @@
             }
         },
         {
+            "name": "appliesToLogisticsRemote",
+            "component": "Chip",
+            "mapper": "booleanToWord",
+            "filter": {
+                "component": "Select",
+                "remote": true,
+                "componentAttributes": {
+                    "translateLabels": true,
+                    "options": {
+                        "endpoint": {
+                          "service": "view",
+                          "namespace": "menu",
+                          "method": "list",
+                          "resolve": false
+                        },
+                        "searchParam": "filters[name]",
+                        "valuesMapper": {
+                          "label": "name",
+                          "value": "id"
+                        }
+                    }
+                }
+            }
+        },
+        {
             "name": "flags",
             "component": "Chip",
             "label": "sac.entities.claimType.fields.appliesTo",

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -217,6 +217,41 @@
             }
         },
         {
+            "name": "appliesToLogisticsRemote",
+            "component": "Chip",
+            "mapper": "booleanToWord",
+            "filter": {
+                "component": "Select",
+                "remote": true,
+                "componentAttributes": {
+                    "translateLabels": true,
+                    "options": {
+                        "endpoint": {
+                            "service": "view",
+                            "namespace": "menu",
+                            "method": "list",
+                            "resolve": false
+                        },
+                        "searchParam": "filters[name]",
+                        "valuesMapper": {
+                            "label": "name",
+                            "value": "id"
+                        }
+                    }
+                },
+                "type": "equal"
+            },
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "borderColor": "grey"
+            }
+        },
+        {
             "name": "flags",
             "component": "Chip",
             "label": "sac.entities.claimType.fields.appliesTo",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -217,6 +217,41 @@
             }
         },
         {
+            "name": "appliesToLogisticsRemote",
+            "component": "Chip",
+            "mapper": "booleanToWord",
+            "filter": {
+                "component": "Select",
+                "remote": true,
+                "componentAttributes": {
+                    "translateLabels": true,
+                    "options": {
+                        "endpoint": {
+                            "service": "view",
+                            "namespace": "menu",
+                            "method": "list",
+                            "resolve": false
+                        },
+                        "searchParam": "filters[name]",
+                        "valuesMapper": {
+                            "label": "name",
+                            "value": "id"
+                        }
+                    }
+                },
+                "type": "equal"
+            },
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "borderColor": "grey"
+            }
+        },
+        {
             "name": "flags",
             "component": "Chip",
             "label": "sac.entities.claimType.fields.appliesTo",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-819

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe validar un select en los filtros del schema de Browse.

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego al select de los filtros del schema de browse nuevas props para que puedan ser remotas y locales

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README