### PR TITLE
add labelPrefix in selects

### DIFF
--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -6,6 +6,7 @@ module.exports = makeComponent({
 	name: 'Select',
 	properties: {
 		translateLabels: { type: 'boolean', default: true },
+		labelPrefix: { type: 'string' },
 		options: {
 			oneOf: [
 				{

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -10,6 +10,7 @@ module.exports = makeComponent({
 	name: [select, multiselect],
 	properties: {
 		translateLabels: { type: 'boolean' },
+		labelPrefix: { type: 'string' },
 		labelFieldName: { type: 'string' },
 		options: {
 			type: 'object',

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -116,13 +116,14 @@
                 "component": "Select",
                 "componentAttributes": {
                     "translateLabels": true,
+                    "labelPrefix": "common.boolean.",
                     "options": [
                         {
-                            "label": "common.boolean.yes",
+                            "label": "yes",
                             "value": 1
                         },
                         {
-                            "label": "common.boolean.no",
+                            "label": "no",
                             "value": 0
                         }
                     ]

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -50,15 +50,16 @@ sections:
       componentAttributes:
         translateLabels: true
         labelFieldName: motiveName
+        labelPrefix: common.status.
         options:
           scope: local
           valuesMapper:
             label: name
             value: id
           values:
-            - label: common.status.active
+            - label: active
               value: 1
-            - label: common.status.inactive
+            - label: inactive
               value: 0
 
       validations:

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -192,13 +192,14 @@
                 "component": "Select",
                 "componentAttributes": {
                     "translateLabels": true,
+                    "labelPrefix": "common.boolean.",
                     "options": [
                         {
-                            "label": "common.boolean.yes",
+                            "label": "yes",
                             "value": 1
                         },
                         {
-                            "label": "common.boolean.no",
+                            "label": "no",
                             "value": 0
                         }
                     ]

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -192,13 +192,14 @@
                 "component": "Select",
                 "componentAttributes": {
                     "translateLabels": true,
+                    "labelPrefix": "common.boolean.",
                     "options": [
                         {
-                            "label": "common.boolean.yes",
+                            "label": "yes",
                             "value": 1
                         },
                         {
-                            "label": "common.boolean.no",
+                            "label": "no",
                             "value": 0
                         }
                     ]

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -81,6 +81,7 @@
                             "componentAttributes": {
                                 "translateLabels": true,
                                 "labelFieldName": "motiveName",
+                                "labelPrefix": "common.status.",
                                 "options": {
                                     "scope": "local",
                                     "valuesMapper": {
@@ -89,11 +90,11 @@
                                     },
                                     "values": [
                                         {
-                                            "label": "common.status.active",
+                                            "label": "active",
                                             "value": 1
                                         },
                                         {
-                                            "label": "common.status.inactive",
+                                            "label": "inactive",
                                             "value": 0
                                         }
                                     ]


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-832

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder definir una propiedad en el schema para los selectores (en filtros, edits y creates) para indicar un prefijo para los labels de los selectores.
Debe validar una propiedad opcional con un valor string

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego al select de los filtros y de EdisCreates una property opcional  labelPrefix

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README