### PR TITLE
add validations for files section

### DIFF
--- a/lib/schemas/edit-new/modules/sections/filesSection.js
+++ b/lib/schemas/edit-new/modules/sections/filesSection.js
@@ -12,9 +12,27 @@ module.exports = {
 		properties: {
 			title: { type: 'string' },
 			name: { type: 'string' },
+			fileUploadEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
+			fileRelationEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
+			fileListEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
+			fileDeleteEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
+			filesTypes: {
+				type: 'array',
+				items: {
+					type: 'string'
+				}
+			},
 			rootComponent: { type: 'string', const: filesSection }
 		},
-		required: ['name', 'rootComponent'],
+		required: ['name', 'rootComponent', 'fileUploadEndpoint'],
 		additionalProperties: false
 	}
 };

--- a/lib/schemas/edit-new/modules/sections/filesSection.js
+++ b/lib/schemas/edit-new/modules/sections/filesSection.js
@@ -32,7 +32,7 @@ module.exports = {
 			},
 			rootComponent: { type: 'string', const: filesSection }
 		},
-		required: ['name', 'rootComponent', 'fileUploadEndpoint'],
+		required: ['name', 'rootComponent', 'fileUploadEndpoint', 'fileListEndpoint'],
 		additionalProperties: false
 	}
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -249,6 +249,28 @@ sections:
   rootComponent: LogsBrowseSection
 - name: filesSection
   rootComponent: FilesSection
+  fileUploadEndpoint:
+    service: sac
+    namespace: claim
+    method: upload
+    resolve: false
+  fileRelationEndpoint:
+    service: sac
+    namespace: claim
+    method: upload
+    resolve: false
+  fileListEndpoint:
+    service: sac
+    namespace: claim
+    method: upload
+    resolve: false
+  fileDeleteEndpoint:
+    service: sac
+    namespace: claim
+    method: upload
+    resolve: false
+  filesTypes:
+    - image/png
 - name: orderItemsSection
   rootComponent: OrderItemsSection
 - name: apiKeysSection

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -525,7 +525,32 @@
         },
         {
             "name": "filesSection",
-            "rootComponent": "FilesSection"
+            "rootComponent": "FilesSection",
+            "fileUploadEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "upload",
+                "resolve": false
+            },
+            "fileRelationEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "upload",
+                "resolve": false
+            },
+            "fileListEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "upload",
+                "resolve": false
+            },
+            "fileDeleteEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "upload",
+                "resolve": false
+            },
+            "filesTypes": ["image/png"]
         },
         {
             "name": "orderItemsSection",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-835

DESCRIPCIÓN DEL REQUERIMIENTO

Se deben poder definir nuevas propeties a la seccion de Files

 "fileUploadEndpoint": SOURCE_ENDPOINT,
 "fileRelationEndpoint: SOURCE_ENDPOINT
 "fileListEndpoint": SOURCE_ENDPOINT,
 "fileDeleteEndpoint": SOURCE_ENDPOINT,
 "filesTypes": ["STRING"]


DESCRIPCIÓN DE LA SOLUCIÓN

Se agregaron los siguientes propeties de la seccion de Files. fileUploadEndpoint es la unica Requerida.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README