### PR TITLE
JMV-844 add new properties in select remote edit create

### DIFF
--- a/lib/schemas/edit-new/modules/options/remoteOptions.js
+++ b/lib/schemas/edit-new/modules/options/remoteOptions.js
@@ -12,6 +12,11 @@ module.exports = {
 			endpoint: {
 				$ref: 'schemaDefinitions#/definitions/endpoint'
 			},
+			initialValuesEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
+			initialValuesFilterName: { type: 'string' },
+			initialValuesPathParam: { type: 'string' },
 			searchParam: { type: 'string', default: 'term' },
 			valuesMapper: {
 				type: 'object',

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -131,6 +131,29 @@ sections:
               value: 1
             - label: common.status.inactive
               value: 0
+      - name: selectRemote
+        component: Select
+        validations:
+          - - name: required
+        componentAttributes:
+          translateLabels: true
+          options:
+            scope: remote
+            endpoint:
+              service: sac
+              namespace: claim
+              method: list
+              resolve: false
+            initialValuesEndpoint:
+              service: sac
+              namespace: claim
+              method: list
+              resolve: false
+            initialValuesFilterName: id
+            initialValuesPathParam: name
+            valuesMapper:
+              label: name
+              value: id
       - name: dateTime
         component: DateTimePicker
         componentAttributes:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -254,6 +254,42 @@
                             }
                         },
                         {
+                            "name": "selectRemote",
+                            "component": "Select",
+                            "validations": [
+                                [
+                                    {
+                                        "name": "required"
+                                    }
+                                ]
+                            ],
+                            "componentAttributes": {
+                                "translateLabels": true,
+                                "options": {
+                                    "scope": "remote",
+                                    "searchParam": "term",
+                                    "endpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "initialValuesEndpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "initialValuesFilterName": "id",
+                                    "initialValuesPathParam": "name",
+                                    "valuesMapper": {
+                                        "label": "name",
+                                        "value": "id"
+                                    }
+                                }
+                            }
+                        },
+                        {
                             "name": "dateTime",
                             "component": "DateTimePicker",
                             "componentAttributes": {
@@ -551,7 +587,9 @@
                 "method": "upload",
                 "resolve": false
             },
-            "filesTypes": ["image/png"]
+            "filesTypes": [
+                "image/png"
+            ]
         },
         {
             "name": "orderItemsSection",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-844

DESCRIPCIÓN DEL REQUERIMIENTO

Se deben agregar tres propiedades opcionales para los selectores (Select y MultiSelect) con opciones remotas:

componentAttributes.options.initialValuesEndpoint de tipo Endpoint
componentAttributes.options.initialValuesFilterNamede tipo string.
componentAttributes.options.initialValuesPathParamde tipo string.

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregaron los siguientes properties para los selects remotos del edit create

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README