### PR TITLE
JMV-839 add validation propeties for asyncWrapper

### DIFF
--- a/lib/schemas/browse/modules/components/asyncWrapper.js
+++ b/lib/schemas/browse/modules/components/asyncWrapper.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const { asyncWrapper } = require('../componentNames');
+
+module.exports = makeComponent({
+	name: asyncWrapper,
+	properties: {
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		dataMapping: {
+			type: 'object',
+			additionalProperties: { type: 'string' }
+		},
+		field: {
+			$ref: 'schemaDefinitions#/definitions/browseField'
+		}
+	},
+	requiredProperties: ['dataMapping', 'source', 'field']
+});

--- a/lib/schemas/browse/modules/components/chips.js
+++ b/lib/schemas/browse/modules/components/chips.js
@@ -27,7 +27,7 @@ const chipComponents = [
 					images: { type: 'string' }
 				},
 				additionalProperties: false,
-				required: ['firstname', 'lastname', 'email', 'images']
+				required: ['firstname', 'lastname', 'email']
 			}
 		}
 	},

--- a/lib/schemas/browse/modules/components/index.js
+++ b/lib/schemas/browse/modules/components/index.js
@@ -10,6 +10,7 @@ const fieldList = require('./fieldList');
 const color = require('./color');
 const sacClaimChange = require('./sacClaimChange');
 const link = require('./link');
+const asyncWrapper = require('./asyncWrapper');
 
 module.exports = [
 	...texts,
@@ -21,5 +22,6 @@ module.exports = [
 	badgeLetter,
 	color,
 	sacClaimChange,
-	link
+	link,
+	asyncWrapper
 ];

--- a/lib/schemas/edit-new/modules/components/chips.js
+++ b/lib/schemas/edit-new/modules/components/chips.js
@@ -18,7 +18,7 @@ const chipComponents = [
 					images: { type: 'string' }
 				},
 				additionalProperties: false,
-				required: ['firstname', 'lastname', 'email', 'images']
+				required: ['firstname', 'lastname', 'email']
 			}
 		}
 	},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -68,7 +68,7 @@
                 }
             }
         },
-		{
+        {
             "name": "linkTest",
             "component": "Link"
         },
@@ -85,7 +85,7 @@
         {
             "name": "user1",
             "component": "UserChip"
-		},
+        },
         {
             "name": "user2",
             "component": "UserChip",
@@ -141,15 +141,15 @@
                     "translateLabels": true,
                     "options": {
                         "endpoint": {
-                          "service": "view",
-                          "namespace": "menu",
-                          "method": "list",
-                          "resolve": false
+                            "service": "view",
+                            "namespace": "menu",
+                            "method": "list",
+                            "resolve": false
                         },
                         "searchParam": "filters[name]",
                         "valuesMapper": {
-                          "label": "name",
-                          "value": "id"
+                            "label": "name",
+                            "value": "id"
                         }
                     }
                 }
@@ -244,6 +244,54 @@
                         "callback": "removeRow"
                     }
                 ]
+            }
+        },
+        {
+            "name": "userCreated",
+            "component": "AsyncWrapper",
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "firstname",
+                    "lastname": "lastname",
+                    "email": "email"
+                },
+                "field": {
+                    "name": "user",
+                    "component": "UserChip",
+                    "componentAttributes": {
+                        "userDataSource": {
+                            "email": "email",
+                            "firstname": "firstname",
+                            "lastname": "lastname",
+                            "images": "images"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "name": "asyncUser",
+            "component": "AsyncWrapper",
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "userTest"
+                },
+                "field": {
+                    "name": "userTest",
+                    "component": "Text"
+                }
             }
         }
     ]

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -396,6 +396,81 @@
                     }
                 ]
             }
+        },
+        {
+            "name": "userCreated",
+            "component": "AsyncWrapper",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "firstname",
+                    "lastname": "lastname",
+                    "email": "email"
+                },
+                "field": {
+                    "name": "user",
+                    "component": "UserChip",
+                    "componentAttributes": {
+                        "userDataSource": {
+                            "email": "email",
+                            "firstname": "firstname",
+                            "lastname": "lastname",
+                            "images": "images"
+                        }
+                    },
+                    "attributes": {
+                        "isStatus": false,
+                        "sortable": false,
+                        "isDefaultSort": false,
+                        "initialSortDirection": "desc"
+                    }
+                }
+            }
+        },
+        {
+            "name": "asyncUser",
+            "component": "AsyncWrapper",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "userTest"
+                },
+                "field": {
+                    "name": "userTest",
+                    "component": "Text",
+                    "attributes": {
+                        "isStatus": false,
+                        "sortable": false,
+                        "isDefaultSort": false,
+                        "initialSortDirection": "desc"
+                    },
+                    "componentAttributes": {
+                        "fontWeight": "normal"
+                    }
+                }
+            }
         }
     ],
     "hasPreview": false,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -396,6 +396,81 @@
                     }
                 ]
             }
+        },
+        {
+            "name": "userCreated",
+            "component": "AsyncWrapper",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "firstname",
+                    "lastname": "lastname",
+                    "email": "email"
+                },
+                "field": {
+                    "name": "user",
+                    "component": "UserChip",
+                    "componentAttributes": {
+                        "userDataSource": {
+                            "email": "email",
+                            "firstname": "firstname",
+                            "lastname": "lastname",
+                            "images": "images"
+                        }
+                    },
+                    "attributes": {
+                        "isStatus": false,
+                        "sortable": false,
+                        "isDefaultSort": false,
+                        "initialSortDirection": "desc"
+                    }
+                }
+            }
+        },
+        {
+            "name": "asyncUser",
+            "component": "AsyncWrapper",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "userTest"
+                },
+                "field": {
+                    "name": "userTest",
+                    "component": "Text",
+                    "attributes": {
+                        "isStatus": false,
+                        "sortable": false,
+                        "isDefaultSort": false,
+                        "initialSortDirection": "desc"
+                    },
+                    "componentAttributes": {
+                        "fontWeight": "normal"
+                    }
+                }
+            }
         }
     ],
     "hasPreview": false,


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-839

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe agregar la validación para el componente de listados AsyncWrapper en el package de view-schema-validator, según la documentación de https://fizzmod.atlassian.net/wiki/spaces/JMV/pages/594051232/AsyncWrapper 

El endpoint se debe resolver por default.

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregaron al los componentes de browse uno nuevo. El asyncWrapperr con las properties definidas en la documentacion. Tambien de la propertie images del UserChip se volvio opcional.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README