### PR TITLE
add fileGetEndpoint in file section

### DIFF
--- a/lib/schemas/edit-new/modules/sections/filesSection.js
+++ b/lib/schemas/edit-new/modules/sections/filesSection.js
@@ -24,6 +24,9 @@ module.exports = {
 			fileDeleteEndpoint: {
 				$ref: 'schemaDefinitions#/definitions/endpoint'
 			},
+			fileGetEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
 			filesTypes: {
 				type: 'array',
 				items: {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -293,6 +293,11 @@ sections:
     namespace: claim
     method: upload
     resolve: false
+  fileGetEndpoint:
+    service: sac
+    namespace: claim
+    method: upload
+    resolve: false
   filesTypes:
     - image/png
 - name: orderItemsSection

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -588,6 +588,12 @@
                 "method": "upload",
                 "resolve": false
             },
+            "fileGetEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "upload",
+                "resolve": false
+            },
             "filesTypes": [
                 "image/png"
             ]


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-883

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe agregar la validación para la seccion de Files.
Se debe agregar un nuevo endpoint para getter el file.

El endpoint se debe resolver por default.

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó a la seccion de FIlesSection una nueva prop
fileGetEndpoint que es un tipo source

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README