### PR TITLE
add prop canCreate in browses

### DIFF
--- a/lib/schema-modifier.js
+++ b/lib/schema-modifier.js
@@ -34,7 +34,7 @@ class SchemaModifier {
 	}
 
 	static execute(data) {
-		if(this.isBrowse(data) && !data.actions)
+		if(this.isBrowse(data) && !data.actions && data.canCreate)
 			return this.addBrowseActions(data);
 
 		return data;

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -52,6 +52,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		},
 		hasPreview: { type: 'boolean', default: false },
 		canEdit: { type: 'boolean', default: true },
+		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },
 		filters,
 		pageSize: { enum: PAGE_SIZES, default: DEFAULT_PAGE_SIZE }

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -529,6 +529,7 @@
     ],
     "hasPreview": false,
     "canEdit": true,
+    "canCreate": true,
     "canView": false,
     "pageSize": 60
 }

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -529,6 +529,7 @@
     ],
     "hasPreview": false,
     "canEdit": true,
+    "canCreate": true,
     "canView": false,
     "pageSize": 60,
     "actions": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -554,6 +554,7 @@
             ],
             "hasPreview": false,
             "canEdit": true,
+            "canCreate": true,
             "canView": false,
             "pageSize": 60
         },

--- a/tests/schema-modifier-test.js
+++ b/tests/schema-modifier-test.js
@@ -38,6 +38,19 @@ describe('Test schema-modifier functions', () => {
 		assert.deepEqual(dataOne, schemaTwo);
 	});
 
+	it('should pass validation and not add actions default if canCreate property is false', () => {
+		const schemaOne = JSON.parse(schemaCompiled.toString());
+		const addBrowseActionsSpy = sandbox.spy(schemaModifier, 'addBrowseActions');
+
+		schemaOne.canCreate = false;
+
+		const dataOne = schemaModifier.execute(schemaOne);
+
+		assert(addBrowseActionsSpy.notCalled);
+
+		assert.deepEqual(dataOne, schemaOne);
+	});
+
 	it('should pass validation with out changes in browse.json compiled', async () => {
 		const schemaOne = JSON.parse(schemaCompiled.toString());
 


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-883

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe aceptar una nueva propiedad opcional canCreate con valor booleano en los listados.
En caso de no estar definida, el valor default debe ser true
En caso de ser false, no se debe insertar la acción por default de New

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó a las properties de browse la nueva prop de canCreate y se modifico el schemaModifier js para que tome en cuenta al meter las actions default cuando canCreate sea true

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README