### PR TITLE
add target optional in edits

### DIFF
--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -34,5 +34,5 @@ module.exports = {
 		}
 	},
 	additionalProperties: false,
-	required: [...required, 'sections', 'target']
+	required: [...required, 'sections']
 };

--- a/lib/schemas/new/schema.js
+++ b/lib/schemas/new/schema.js
@@ -2,4 +2,7 @@
 
 const newEditSchema = require('../edit-new/schema');
 
-module.exports = newEditSchema;
+module.exports = {
+	...newEditSchema,
+	required: [...newEditSchema.required, 'target']
+};

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -6,11 +6,6 @@ source:
   namespace: claim-motive
   method: get
   resolve: false
-target:
-  service: sac
-  namespace: claim-motive
-  method: save
-  resolve: false
 header:
   title:
     beforeId:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -8,12 +8,6 @@
         "method": "get",
         "resolve": false
     },
-    "target": {
-        "service": "sac",
-        "namespace": "claim-motive",
-        "method": "save",
-        "resolve": false
-    },
     "header": {
         "title": {
             "beforeId": [


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-863

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe cambiar la validación de los edits para que los targets sean opcionales.

DESCRIPCIÓN DE LA SOLUCIÓN

Se saco de requeridos la prop de target en edit y se cambio el schema de new para que solo ahí sea requerido.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README