### PR TITLE
add new prop in fieldsArray

### DIFF
--- a/lib/schemas/edit-new/modules/components/fieldsArray.js
+++ b/lib/schemas/edit-new/modules/components/fieldsArray.js
@@ -13,6 +13,7 @@ module.exports = makeComponent({
 			},
 			minItems: 1
 		},
+		uniqueField: { type: 'boolean' },
 		canChangeElements: { type: 'boolean' },
 		minElements: { type: 'number' }
 	},

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -116,6 +116,15 @@ sections:
         fields:
           - name: test
             component: Text
+    - name: fieldsArrayTwo
+      component: FieldsArray
+      componentAttributes:
+        canChangeElements: true
+        uniqueField: true
+        minElements: 1
+        fields:
+          - name: test
+            component: Text
   - name: others
     fields:
       - name: status

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -220,6 +220,22 @@
                                     }
                                 ]
                             }
+                        },
+                        {
+                            "name": "fieldsArrayTwo",
+                            "component": "FieldsArray",
+                            "componentAttributes": {
+                                "canChangeElements": true,
+                                "minElements": 1,
+                                "uniqueField": true,
+                                "fields": [
+                                    {
+                                        "name": "test",
+                                        "component": "Text",
+                                        "componentAttributes": {}
+                                    }
+                                ]
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-871

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe definir una nueva propiedad que indique que se maneja un solo campo, y que la data se debe manejar como un array de valores en lugar de array de objetos.

uniqueField: boolean

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego la propiedad uniqueField en el componente de FieldsArray como booleano opcional.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README