### PR TITLE
add deviceDisplay in browse fields

### DIFF
--- a/lib/schemas/browse/modules/field.js
+++ b/lib/schemas/browse/modules/field.js
@@ -12,6 +12,7 @@ module.exports = {
 		name: { type: 'string' },
 		label: { type: 'string' },
 		noLabel: { type: 'boolean' },
+		deviceDisplay: { enum: ['desktop', 'mobile'] },
 		attributes: {
 			type: 'object',
 			properties: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -87,11 +87,13 @@
                 "sortable": true,
                 "isDefaultSort": true
             },
+            "deviceDisplay": "desktop",
             "mapper": "addHashtag"
         },
         {
             "name": "motiveName",
             "component": "MediumText",
+            "deviceDisplay": "mobile",
             "filter": {
                 "component": "Input"
             }

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -88,6 +88,7 @@
                 "isStatus": false,
                 "initialSortDirection": "desc"
             },
+            "deviceDisplay": "desktop",
             "mapper": "addHashtag",
             "componentAttributes": {
                 "fontWeight": "bold"
@@ -108,6 +109,7 @@
                 "isDefaultSort": false,
                 "initialSortDirection": "desc"
             },
+            "deviceDisplay": "mobile",
             "componentAttributes": {
                 "fontWeight": "medium"
             }

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -88,6 +88,7 @@
                 "isStatus": false,
                 "initialSortDirection": "desc"
             },
+            "deviceDisplay": "desktop",
             "mapper": "addHashtag",
             "componentAttributes": {
                 "fontWeight": "bold"
@@ -108,6 +109,7 @@
                 "isDefaultSort": false,
                 "initialSortDirection": "desc"
             },
+            "deviceDisplay": "mobile",
             "componentAttributes": {
                 "fontWeight": "medium"
             }


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-824

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe definir una nueva propiedad que indique si una field de browse se va a ver en desktop o mobile solamente.

deviceDisplay: ["desktop", "mobile"]

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego la propiedad deviceDisplay en el componente de Field de browse con un enum de ["desktop", "mobile"]

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README