### PR TITLE
Jmv 896 status themes

### DIFF
--- a/lib/schemas/browse/modules/components/chips.js
+++ b/lib/schemas/browse/modules/components/chips.js
@@ -42,7 +42,7 @@ const chipComponents = [
 	{
 		name: statusChip,
 		properties: {
-			useTheme: { type: 'boolean' },
+			useTheme: { type: ['boolean', 'string'] },
 			colorSource: { type: 'string' }
 		},
 		conditions: {

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const filters = require('../browse/modules/filters');
+const themes = require('./status-themes');
 
 const PAGE_SIZES = [15, 30, 60, 100];
 const DEFAULT_PAGE_SIZE = 60;
@@ -54,6 +55,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		canEdit: { type: 'boolean', default: true },
 		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },
+		themes,
 		filters,
 		pageSize: { enum: PAGE_SIZES, default: DEFAULT_PAGE_SIZE }
 	};

--- a/lib/schemas/common/status-themes.js
+++ b/lib/schemas/common/status-themes.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+	type: 'object',
+	additionalProperties: {
+		type: 'object',
+		additionalProperties: { type: 'string' }
+	},
+	minProperties: 1
+};

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -1,5 +1,12 @@
 'use strict';
 
 const newEditSchema = require('../edit-new/schema');
+const themes = require('../common/status-themes');
 
-module.exports = newEditSchema;
+module.exports = {
+	...newEditSchema,
+	properties: {
+		...newEditSchema.properties,
+		themes
+	}
+};

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -27,6 +27,17 @@
             }
         }
     ],
+    "themes": {
+        "themeOne": {
+            "new": "black",
+            "closed": "green",
+            "_default": "grey"
+        },
+        "themeTwo": {
+            "new": "grey",
+            "closed": "fizzgreen"
+        }
+    },
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -294,6 +294,13 @@
             }
         },
         {
+            "name": "statusWithThemeCustom",
+            "component": "StatusChip",
+            "componentAttributes": {
+                "useTheme": "themeOne"
+            }
+        },
+        {
             "name": "actions",
             "component": "ActionButtons",
             "componentAttributes": {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -16,6 +16,10 @@ header:
         component: StatusChip
         componentAttributes:
           useTheme: true
+      - name: test2
+        component: StatusChip
+        componentAttributes:
+          useTheme: themeOne
 themes:
   themeOne:
     new: black

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -16,6 +16,14 @@ header:
         component: StatusChip
         componentAttributes:
           useTheme: true
+themes:
+  themeOne:
+    new: black
+    closed: green
+    _default: grey
+  themeTwo:
+    new: grey
+    closed: fizzgreen
 sections:
 - name: mainFormSection
   rootComponent: MainForm

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -441,6 +441,19 @@
             }
         },
         {
+            "name": "statusWithThemeCustom",
+            "component": "StatusChip",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "useTheme": "themeOne"
+            }
+        },
+        {
             "name": "actions",
             "component": "ActionButtons",
             "attributes": {

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -24,6 +24,17 @@
             }
         }
     ],
+    "themes": {
+        "themeOne": {
+            "new": "black",
+            "closed": "green",
+            "_default": "grey"
+        },
+        "themeTwo": {
+            "new": "grey",
+            "closed": "fizzgreen"
+        }
+    },
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -441,6 +441,19 @@
             }
         },
         {
+            "name": "statusWithThemeCustom",
+            "component": "StatusChip",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "useTheme": "themeOne"
+            }
+        },
+        {
             "name": "actions",
             "component": "ActionButtons",
             "attributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -24,6 +24,17 @@
             }
         }
     ],
+    "themes": {
+        "themeOne": {
+            "new": "black",
+            "closed": "green",
+            "_default": "grey"
+        },
+        "themeTwo": {
+            "new": "grey",
+            "closed": "fizzgreen"
+        }
+    },
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -26,6 +26,13 @@
                     "componentAttributes": {
                         "useTheme": true
                     }
+                },
+                {
+                    "name": "test2",
+                    "component": "StatusChip",
+                    "componentAttributes": {
+                        "useTheme": "themeOne"
+                    }
                 }
             ]
         }

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -30,6 +30,17 @@
             ]
         }
     },
+    "themes": {
+        "themeOne": {
+            "new": "black",
+            "closed": "green",
+            "_default": "grey"
+        },
+        "themeTwo": {
+            "new": "grey",
+            "closed": "fizzgreen"
+        }
+    },
     "sections": [
         {
             "name": "mainFormSection",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-896

DESCRIPCIÓN DEL REQUERIMIENTO

Se deben poder definir distintos temas en un schema para manejar los colores de los distintos campos en el root del schema,

Estructura de referencia de lo que se necesita:

themes: # Opcional
  statusTheme: # Nombre del tema. Objeto de la forma string:string.
    new: darkGrey # Mapeo de un valor a su color
    readyForPicking: fizzGreen
    _default: statusRed # Valor default en caso de no tener el mapeo definido

Se debe validar que la propiedad componentAttributes.useTheme del StatusChip pueda aceptar un boolean o un string (el nombre del tema)

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego al schema de edit y listados la prop de themes para que pueda tener la estructura definida arriba.
Tambien se cambio el valor del tipo de datos que puede ser useTheme en los StatusChip

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README

