### PR TITLE
add new prop in multi input

### DIFF
--- a/lib/schemas/edit-new/modules/components/multiInput.js
+++ b/lib/schemas/edit-new/modules/components/multiInput.js
@@ -7,6 +7,12 @@ module.exports = makeComponent({
 	name: multiInput,
 	properties: {
 		labelsPrefix: { type: 'string', default: '' },
-		translateLabels: { type: 'boolean', default: true }
+		labelPrefix: { type: 'string', default: '' },
+		translateLabels: { type: 'boolean', default: true },
+		requiredFields: {
+			type: 'array',
+			items: { type: 'string' },
+			minItems: 1
+		}
 	}
 });

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -200,6 +200,15 @@ sections:
           translateSectionLabel: true
           translateGroupLabel: false
           translateCheckboxLabel: false
+      - name: multiInputExample
+        component: MultiInput
+        componentAttributes:
+          labelsPrefix: common.test.
+          labelPrefix: common.test.
+          translateLabels: true
+          requiredFields:
+            - test
+            - test2
 
 - name: semaphoreBrowse
   rootComponent: BrowseSection

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -373,6 +373,19 @@
                                 "translateGroupLabel": false,
                                 "translateCheckboxLabel": false
                             }
+                        },
+                        {
+                            "name": "multiInputExample",
+                            "component": "MultiInput",
+                            "componentAttributes": {
+                                "labelsPrefix": "common.test.",
+                                "labelPrefix": "common.test.",
+                                "translateLabels": true,
+                                "requiredFields": [
+                                    "test",
+                                    "test2"
+                                ]
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-895

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe poder definir una nueva propiedad opcional, que defina un array de nombres de campos que se deben mostrar siempre en un MultiInput. Debe ser un array de strings.

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego al compoenente MultiInput nuevas props, requiredFields que es un array de campos con los nombre de los campos a mostar en el multiInput y se agrego labelPrefix para estandarizar nombres.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README
