### PR TITLE
add sortable field in browses

### DIFF
--- a/lib/schemas/browse/modules/sortableFields/index.js
+++ b/lib/schemas/browse/modules/sortableFields/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const sortableFields = require('./sortableFields');
+
+module.exports = sortableFields;

--- a/lib/schemas/browse/modules/sortableFields/sortableFields.js
+++ b/lib/schemas/browse/modules/sortableFields/sortableFields.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			name: { type: 'string' },
+			isDefaultSort: { type: 'boolean', default: false },
+			initialSortDirection: {
+				type: 'string',
+				enum: ['desc', 'asc'],
+				default: 'desc'
+			}
+		},
+		additionalProperties: false,
+		required: ['name']
+	}
+};

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const filters = require('../browse/modules/filters');
+const sortableFields = require('../browse/modules/sortableFields');
 
 const PAGE_SIZES = [15, 30, 60, 100];
 const DEFAULT_PAGE_SIZE = 60;
@@ -55,6 +56,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },
 		filters,
+		sortableFields,
 		pageSize: { enum: PAGE_SIZES, default: DEFAULT_PAGE_SIZE }
 	};
 };

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -27,6 +27,19 @@
             }
         }
     ],
+    "sortableFields": [
+        {
+            "name": "test"
+        },
+        {
+            "name": "test1",
+            "isDefaultSort": true
+        },
+        {
+            "name": "test2",
+            "initialSortDirection": "asc"
+        }
+    ],
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -24,6 +24,23 @@
             }
         }
     ],
+    "sortableFields": [
+        {
+            "name": "test",
+            "isDefaultSort": false,
+            "initialSortDirection": "desc"
+        },
+        {
+            "name": "test1",
+            "isDefaultSort": true,
+            "initialSortDirection": "desc"
+        },
+        {
+            "name": "test2",
+            "isDefaultSort": false,
+            "initialSortDirection": "asc"
+        }
+    ],
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -24,6 +24,23 @@
             }
         }
     ],
+    "sortableFields": [
+        {
+            "name": "test",
+            "isDefaultSort": false,
+            "initialSortDirection": "desc"
+        },
+        {
+            "name": "test1",
+            "isDefaultSort": true,
+            "initialSortDirection": "desc"
+        },
+        {
+            "name": "test2",
+            "isDefaultSort": false,
+            "initialSortDirection": "asc"
+        }
+    ],
     "filters": [
         {
             "name": "filterInput",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-894

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe implementar una nueva propiedad para definir los campos ordenables (nombre y dirección inicial), y para definir el orden default (nombre). (similar a lo que se hizo con los filtros)

Se debe seguir validando el ordenamiento tal como estaba anteriormente para dar retrocompatibilidad

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó al schema al schema de browse una nueva propiedad para definir los ordenamientos. En un array de objetos definiendo el name, si es default y su .dirección

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README