### PR TITLE
add multiselect in filters and add mapper in components header edit

### DIFF
--- a/lib/schemas/browse/modules/filters/componentNames.js
+++ b/lib/schemas/browse/modules/filters/componentNames.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	select: 'Select',
+	multiselect: 'Multiselect',
 	input: 'Input',
 	dateTimePicker: 'DateTimePicker'
 };

--- a/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
+++ b/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
@@ -12,6 +12,11 @@ module.exports = {
 			endpoint: {
 				$ref: 'schemaDefinitions#/definitions/endpoint'
 			},
+			initialValuesEndpoint: {
+				$ref: 'schemaDefinitions#/definitions/endpoint'
+			},
+			initialValuesFilterName: { type: 'string' },
+			initialValuesPathParam: { type: 'string' },
 			searchParam: { type: 'string', default: 'term' },
 			valuesMapper: {
 				type: 'object',

--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const { makeComponent } = require('../../../../utils');
-const { select } = require('../componentNames');
+const { select, multiselect } = require('../componentNames');
 const options = require('./select-options');
 
 module.exports = makeComponent({
-	name: select,
+	name: [select, multiselect],
 	properties: {
 		translateLabels: { type: 'boolean' },
 		labelPrefix: { type: 'string' },

--- a/lib/schemas/edit-new/modules/headerProperties.js
+++ b/lib/schemas/edit-new/modules/headerProperties.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const components = require('../../browse/modules/components');
+const mapper = require('../../common/mapper');
 const { badgeLetter, statusChip } = require('../../browse/modules/componentNames');
 
 const commonAfterBefore = {
@@ -10,6 +11,7 @@ const commonAfterBefore = {
 		properties: {
 			name: { type: 'string' },
 			component: { enum: [badgeLetter, statusChip] },
+			mapper,
 			componentAttributes: {
 				type: 'object',
 				default: {}

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -70,6 +70,33 @@
             }
         },
         {
+            "name": "remoteMultiselect",
+            "component": "Multiselect",
+            "componentAttributes": {
+                "translateLabels": true,
+                "options": {
+                    "scope": "remote",
+                    "initialValuesEndpoint":{
+                        "service": "sac",
+                        "namespace": "claim-type",
+                        "method": "list",
+                        "resolve": false
+                    },
+                    "initialValuesFilterName": "id",
+                    "endpoint": {
+                        "service": "sac",
+                        "namespace": "claim-type",
+                        "method": "list",
+                        "resolve": false
+                    },
+                    "valuesMapper": {
+                        "label": "name",
+                        "value": "id"
+                    }
+                }
+            }
+        },
+        {
             "name": "dateTimePickerFilter",
             "component": "DateTimePicker",
             "componentAttributes": {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -14,6 +14,7 @@ header:
     afterId:
       - name: test
         component: StatusChip
+        mapper: translate
         componentAttributes:
           useTheme: true
 sections:

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -69,6 +69,34 @@
             }
         },
         {
+            "name": "remoteMultiselect",
+            "component": "Multiselect",
+            "componentAttributes": {
+                "translateLabels": true,
+                "options": {
+                    "scope": "remote",
+                    "searchParam": "term",
+                    "initialValuesEndpoint":{
+                        "service": "sac",
+                        "namespace": "claim-type",
+                        "method": "list",
+                        "resolve": false
+                    },
+                    "initialValuesFilterName": "id",
+                    "endpoint": {
+                        "service": "sac",
+                        "namespace": "claim-type",
+                        "method": "list",
+                        "resolve": false
+                    },
+                    "valuesMapper": {
+                        "label": "name",
+                        "value": "id"
+                    }
+                }
+            }
+        },
+        {
             "name": "dateTimePickerFilter",
             "component": "DateTimePicker",
             "componentAttributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -69,6 +69,34 @@
             }
         },
         {
+            "name": "remoteMultiselect",
+            "component": "Multiselect",
+            "componentAttributes": {
+                "translateLabels": true,
+                "options": {
+                    "scope": "remote",
+                    "searchParam": "term",
+                    "initialValuesEndpoint":{
+                        "service": "sac",
+                        "namespace": "claim-type",
+                        "method": "list",
+                        "resolve": false
+                    },
+                    "initialValuesFilterName": "id",
+                    "endpoint": {
+                        "service": "sac",
+                        "namespace": "claim-type",
+                        "method": "list",
+                        "resolve": false
+                    },
+                    "valuesMapper": {
+                        "label": "name",
+                        "value": "id"
+                    }
+                }
+            }
+        },
+        {
             "name": "dateTimePickerFilter",
             "component": "DateTimePicker",
             "componentAttributes": {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -23,6 +23,7 @@
                 {
                     "name": "test",
                     "component": "StatusChip",
+                    "mapper": "translate",
                     "componentAttributes": {
                         "useTheme": true
                     }


### PR DESCRIPTION

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe implementar los multiselects en los filtros nuevos del browse
y agregar mappers a los componentes del header de edit

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó al schema del select de los filtros los multiselect y nuevas props para initial values. Se agrego mappper al componente de header de edits.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README