### PR TITLE
add new propeerties on section products and refactor staticFilters

### DIFF
--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -3,28 +3,13 @@
 const filters = require('../browse/modules/filters');
 const themes = require('./status-themes');
 const sortableFields = require('../browse/modules/sortableFields');
+const getStaticFilters = require('./staticFilters');
 
 const PAGE_SIZES = [15, 30, 60, 100];
 const DEFAULT_PAGE_SIZE = 60;
 
 
 const getBrowseBaseSchema = (isPage = false) => {
-	const getStaticFiltersValue = () => {
-		const dynamicProps = !isPage ? { dynamic: { type: 'string' } } : {};
-
-		return {
-			...dynamicProps,
-			static: {
-				anyOf: [
-					{ type: 'string' },
-					{ type: 'number' },
-					{ type: 'array' },
-					{ type: 'object' }
-				]
-			}
-		};
-	};
-
 	return {
 		fields: {
 			type: 'array',
@@ -33,25 +18,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 			},
 			minItems: 1
 		},
-		staticFilters: {
-			type: 'array',
-			items: {
-				type: 'object',
-				properties: {
-					name: { type: 'string' },
-					target: { enum: ['path', 'query'] },
-					value: {
-						type: 'object',
-						properties: getStaticFiltersValue(),
-						additionalProperties: false,
-						minProperties: 1,
-						maxProperties: 1
-					}
-				},
-				required: ['name', 'target', 'value']
-			},
-			minItems: 1
-		},
+		staticFilters: getStaticFilters(isPage),
 		hasPreview: { type: 'boolean', default: false },
 		canEdit: { type: 'boolean', default: true },
 		canCreate: { type: 'boolean', default: true },

--- a/lib/schemas/common/staticFilters.js
+++ b/lib/schemas/common/staticFilters.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const getStaticFiltersValue = isPage => {
+	const dynamicProps = !isPage ? { dynamic: { type: 'string' } } : {};
+
+	return {
+		...dynamicProps,
+		static: {
+			anyOf: [
+				{ type: 'string' },
+				{ type: 'number' },
+				{ type: 'array' },
+				{ type: 'object' }
+			]
+		}
+	};
+};
+
+module.exports = isPage => ({
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			name: { type: 'string' },
+			target: { enum: ['path', 'query'] },
+			value: {
+				type: 'object',
+				properties: getStaticFiltersValue(isPage),
+				additionalProperties: false,
+				minProperties: 1,
+				maxProperties: 1
+			}
+		},
+		additionalProperties: false,
+		required: ['name', 'target', 'value']
+	},
+	minItems: 1
+});

--- a/lib/schemas/edit-new/modules/sections/orderItemsSection.js
+++ b/lib/schemas/edit-new/modules/sections/orderItemsSection.js
@@ -3,19 +3,6 @@
 const { orderItemsSection } = require('../sectionsNames');
 const getStaticFilters = require('../../../common/staticFilters');
 
-const commonProps = {
-	properties: {
-		title: { type: 'string' },
-		name: { type: 'string' },
-		rootComponent: { type: 'string', const: orderItemsSection },
-		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-		sourceField: { type: 'string' },
-		staticFilters: getStaticFilters()
-	},
-	required: ['name', 'rootComponent'],
-	additionalProperties: false
-};
-
 module.exports = {
 	if: {
 		properties: {
@@ -23,20 +10,15 @@ module.exports = {
 		}
 	},
 	then: {
-		if: {
-			properties: {
-				source: false,
-				sourceField: false
-			}
+		properties: {
+			title: { type: 'string' },
+			name: { type: 'string' },
+			rootComponent: { type: 'string', const: orderItemsSection },
+			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			sourceField: { type: 'string' },
+			staticFilters: getStaticFilters()
 		},
-		then: {
-			...commonProps,
-			required: [
-				...commonProps.required,
-				'source',
-				'sourceField'
-			]
-		},
-		else: commonProps
+		required: ['name', 'rootComponent'],
+		additionalProperties: false
 	}
 };

--- a/lib/schemas/edit-new/modules/sections/orderItemsSection.js
+++ b/lib/schemas/edit-new/modules/sections/orderItemsSection.js
@@ -1,6 +1,20 @@
 'use strict';
 
 const { orderItemsSection } = require('../sectionsNames');
+const getStaticFilters = require('../../../common/staticFilters');
+
+const commonProps = {
+	properties: {
+		title: { type: 'string' },
+		name: { type: 'string' },
+		rootComponent: { type: 'string', const: orderItemsSection },
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		sourceField: { type: 'string' },
+		staticFilters: getStaticFilters()
+	},
+	required: ['name', 'rootComponent'],
+	additionalProperties: false
+};
 
 module.exports = {
 	if: {
@@ -9,12 +23,20 @@ module.exports = {
 		}
 	},
 	then: {
-		properties: {
-			title: { type: 'string' },
-			name: { type: 'string' },
-			rootComponent: { type: 'string', const: orderItemsSection }
+		if: {
+			properties: {
+				source: false,
+				sourceField: false
+			}
 		},
-		required: ['name', 'rootComponent'],
-		additionalProperties: false
+		then: {
+			...commonProps,
+			required: [
+				...commonProps.required,
+				'source',
+				'sourceField'
+			]
+		},
+		else: commonProps
 	}
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -349,6 +349,26 @@ sections:
     - image/png
 - name: orderItemsSection
   rootComponent: OrderItemsSection
+  sourceField: items
+  source:
+    service: oms
+    namespace: order
+    method: get
+    resolve: false
+  staticFilters:
+    - name: status
+      target: path
+      value:
+        dynamic: statusId
+    - name: status
+      target: query
+      value:
+        static: 1
+    - name: status
+      target: query
+      value:
+        static:
+          id: "string"
 - name: apiKeysSection
   rootComponent: ApiKeysSection
   parentIdField: user

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -369,6 +369,10 @@ sections:
       value:
         static:
           id: "string"
+
+- name: anotherOrderItemsSection
+  rootComponent: OrderItemsSection
+
 - name: apiKeysSection
   rootComponent: ApiKeysSection
   parentIdField: user

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -725,6 +725,10 @@
             ]
         },
         {
+            "name": "anotherOrderItemsSection",
+            "rootComponent": "OrderItemsSection"
+        },
+        {
             "name": "apiKeysSection",
             "rootComponent": "ApiKeysSection",
             "parentIdField": "user",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -690,7 +690,39 @@
         },
         {
             "name": "orderItemsSection",
-            "rootComponent": "OrderItemsSection"
+            "rootComponent": "OrderItemsSection",
+            "sourceField": "items",
+            "source": {
+                "service": "oms",
+                "namespace": "order",
+                "method": "get",
+                "resolve": false
+            },
+            "staticFilters": [
+                {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                        "dynamic": "statusId"
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": 1
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": {
+                            "id": "string"
+                        }
+                    }
+                }
+            ]
         },
         {
             "name": "apiKeysSection",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-934

**DESCRIPCIÓN DEL REQUERIMIENTO**

La sección de OrderItems debe aceptar una propiedad `source` de tipo Endpoint, que indique de dónde se deben gettear los productos

En caso de tener esta propiedad también debe aceptar la propiedad `staticFilters` idéntica a la de BrowseSection

También debe aceptar una propiedad `sourceField` de tipo string, que indique en qué propiedad de la data del edit se encuentran los items.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó al schema de la seccion de OrderItems nuevas propeties para que tenga `source`, `staticFilters` y `sourceField`.
Se refactorizó los staticFilters porque se usa y se va a usar en más lugares.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README