### PR TITLE
Jmv 927 code component new prop

### DIFF
--- a/lib/schemas/edit-new/modules/components/code.js
+++ b/lib/schemas/edit-new/modules/components/code.js
@@ -6,6 +6,7 @@ const { code } = require('../componentNames');
 module.exports = makeComponent({
 	name: code,
 	properties: {
-		language: { type: 'string' }
+		language: { type: 'string' },
+		canEdit: { type: 'boolean' }
 	}
 });

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -124,12 +124,18 @@ sections:
           image: image
     - name: color
       component: ColorPicker
+
     - name: exampleCode
       component: Code
+      componentAttributes:
+        canEdit: false
+
     - name: exampleCodeTwo
       component: Code
       componentAttributes:
         language: json
+        canEdit: true
+
     - name: linkTest
       component: Link
       componentAttributes:

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -127,8 +127,6 @@ sections:
 
     - name: exampleCode
       component: Code
-      componentAttributes:
-        canEdit: false
 
     - name: exampleCodeTwo
       component: Code

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -247,9 +247,7 @@
                         {
                             "name": "exampleCode",
                             "component": "Code",
-                            "componentAttributes": {
-                                "canEdit": false
-                            }
+                            "componentAttributes": {}
                         },
                         {
                             "name": "exampleCodeTwo",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -247,13 +247,16 @@
                         {
                             "name": "exampleCode",
                             "component": "Code",
-                            "componentAttributes": {}
+                            "componentAttributes": {
+                                "canEdit": false
+                            }
                         },
                         {
                             "name": "exampleCodeTwo",
                             "component": "Code",
                             "componentAttributes": {
-                                "language": "json"
+                                "language": "json",
+                                "canEdit": true
                             }
                         },
                         {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-934

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe poder definir una propiedad opcional y booleana para indicar que el componente `Code` es editable.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó al schema del componente `Code` una nueva prop llamada `canEdit` .

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README