### PR TITLE
add triggers for edit/create fields

### DIFF
--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -4,6 +4,7 @@ const mapper = require('../../common/mapper');
 const attributes = require('./attributes');
 const validations = require('./validations');
 const conditions = require('./conditions');
+const triggers = require('./triggers');
 const components = require('./components');
 const componentNames = require('./componentNames');
 
@@ -21,6 +22,7 @@ module.exports = {
 		},
 		validations,
 		conditions,
+		triggers,
 		mapper
 	},
 	allOf: components,

--- a/lib/schemas/edit-new/modules/triggers/index.js
+++ b/lib/schemas/edit-new/modules/triggers/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const triggers = require('./triggers');
+
+module.exports = triggers;

--- a/lib/schemas/edit-new/modules/triggers/triggers.js
+++ b/lib/schemas/edit-new/modules/triggers/triggers.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const getStaticFilters = require('../../../common/staticFilters');
+
+module.exports = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			endpointParameters: getStaticFilters(),
+			dataMapping: {
+				type: 'object',
+				additionalProperties: { type: 'string' }
+			},
+			triggerOnLoad: { type: 'boolean' }
+		},
+		requiredProperties: ['endpoint', 'dataMapping']
+	},
+	minItems: 1
+};

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -164,6 +164,35 @@ sections:
         translateLabels: true
         label: test.test.test
         labelField: asdasd
+
+    - name: fieldTriggers
+      component: Input
+      triggers:
+        - endpoint:
+            service: sac
+            namespace: claim
+            method: list
+            resolve: false
+          endpointParameters:
+            - name: status
+              target: path
+              value:
+                dynamic: id
+            - name: status
+              target: query
+              value:
+                static: 1
+          dataMapping:
+            name: firstname
+          triggerOnLoad: true
+        - endpoint:
+            service: sac
+            namespace: claim
+            method: list
+            resolve: false
+          dataMapping:
+            name: firstname
+
     - name: fieldsArray
       component: FieldsArray
       componentAttributes:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -304,6 +304,52 @@
                             }
                         },
                         {
+                            "name": "fieldTriggers",
+                            "component": "Input",
+                            "componentAttributes": {},
+                            "triggers": [
+                                {
+                                    "endpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "endpointParameters": [
+                                        {
+                                            "name": "status",
+                                            "target": "path",
+                                            "value": {
+                                                "dynamic": "id"
+                                            }
+                                        },
+                                        {
+                                            "name": "status",
+                                            "target": "query",
+                                            "value": {
+                                                "static": 1
+                                            }
+                                        }
+                                    ],
+                                    "dataMapping": {
+                                        "name": "firstname"
+                                    },
+                                    "triggerOnLoad": true
+                                },
+                                {
+                                    "endpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "dataMapping": {
+                                        "name": "firstname"
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "fieldsArray",
                             "component": "FieldsArray",
                             "componentAttributes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-967

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe validar una nueva propiedad opcional en los campos de formularios: triggers.
Debe ser un array de objetos con la siguiente estructura:

**endpoint**: Endpoint
**endpointParameters**: StaticFilters
**dataMapping**: object<string: string> // key value de mappeo de campos
**triggerOnLoad**: boolean

las propiedades endpoint y dataMapping son requeridas.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó a los fields de edit/create una nueva propetie `triggers` y se crearon los schemas para estos triggers como se definio en el requerimiento.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README