### PR TITLE
Jmv 968 select remote label template

### DIFF
--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -37,26 +37,7 @@ module.exports = makeComponent({
 						valuesMapper: {
 							type: 'object',
 							properties: {
-								label: {
-									oneOf: [
-										{ type: 'string' },
-										{
-											type: 'object',
-											properties: {
-												template: { type: 'string' },
-												fields: {
-													type: 'array',
-													items: {
-														type: 'string'
-													},
-													minItems: 1
-												}
-											},
-											required: ['template', 'fields'],
-											additionalProperties: false
-										}
-									]
-								},
+								label: { type: 'string' },
 								value: { type: 'string' }
 							},
 							required: ['label', 'value'],

--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -37,7 +37,26 @@ module.exports = makeComponent({
 						valuesMapper: {
 							type: 'object',
 							properties: {
-								label: { type: 'string' },
+								label: {
+									oneOf: [
+										{ type: 'string' },
+										{
+											type: 'object',
+											properties: {
+												template: { type: 'string' },
+												fields: {
+													type: 'array',
+													items: {
+														type: 'string'
+													},
+													minItems: 1
+												}
+											},
+											required: ['template', 'fields'],
+											additionalProperties: false
+										}
+									]
+								},
 								value: { type: 'string' }
 							},
 							required: ['label', 'value'],

--- a/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
+++ b/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
@@ -21,7 +21,26 @@ module.exports = {
 			valuesMapper: {
 				type: 'object',
 				properties: {
-					label: { type: 'string' },
+					label: {
+						oneOf: [
+							{ type: 'string' },
+							{
+								type: 'object',
+								properties: {
+									template: { type: 'string' },
+									fields: {
+										type: 'array',
+										items: {
+											type: 'string'
+										},
+										minItems: 1
+									}
+								},
+								required: ['template', 'fields'],
+								additionalProperties: false
+							}
+						]
+					},
 					value: { type: 'string' }
 				},
 				required: ['label', 'value'],

--- a/lib/schemas/edit-new/modules/options/remoteOptions.js
+++ b/lib/schemas/edit-new/modules/options/remoteOptions.js
@@ -21,7 +21,26 @@ module.exports = {
 			valuesMapper: {
 				type: 'object',
 				properties: {
-					label: { type: 'string' },
+					label: {
+						oneOf: [
+							{ type: 'string' },
+							{
+								type: 'object',
+								properties: {
+									template: { type: 'string' },
+									fields: {
+										type: 'array',
+										items: {
+											type: 'string'
+										},
+										minItems: 1
+									}
+								},
+								required: ['template', 'fields'],
+								additionalProperties: false
+							}
+						]
+					},
 					value: { type: 'string' }
 				},
 				required: ['label', 'value'],

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -87,7 +87,14 @@
                         "resolve": false
                     },
                     "valuesMapper": {
-                        "label": "name",
+                        "label": {
+                            "template": "{0} {1} - ({2})",
+                            "fields": [
+                                "firstname",
+                                "lastname",
+                                "email"
+                            ]
+                        },
                         "value": "id"
                     }
                 }

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -196,6 +196,7 @@ sections:
               value: 1
             - label: common.status.inactive
               value: 0
+
       - name: selectRemote
         component: Select
         validations:
@@ -219,6 +220,34 @@ sections:
             valuesMapper:
               label: name
               value: id
+
+      - name: selectRemoteTwo
+        component: Select
+        componentAttributes:
+          translateLabels: true
+          options:
+            scope: remote
+            endpoint:
+              service: sac
+              namespace: claim
+              method: list
+              resolve: false
+            initialValuesEndpoint:
+              service: sac
+              namespace: claim
+              method: list
+              resolve: false
+            initialValuesFilterName: id
+            initialValuesPathParam: name
+            valuesMapper:
+              label:
+                template: '{0} {1} - ({2})'
+                fields:
+                 - firstname
+                 - lastname
+                 - email
+              value: id
+
       - name: dateTime
         component: DateTimePicker
         componentAttributes:

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -90,7 +90,14 @@
                         "resolve": false
                     },
                     "valuesMapper": {
-                        "label": "name",
+                        "label": {
+                            "template": "{0} {1} - ({2})",
+                            "fields": [
+                                "firstname",
+                                "lastname",
+                                "email"
+                            ]
+                        },
                         "value": "id"
                     }
                 }

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -90,7 +90,14 @@
                         "resolve": false
                     },
                     "valuesMapper": {
-                        "label": "name",
+                        "label": {
+                            "template": "{0} {1} - ({2})",
+                            "fields": [
+                                "firstname",
+                                "lastname",
+                                "email"
+                            ]
+                        },
                         "value": "id"
                     }
                 }

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -403,6 +403,42 @@
                             }
                         },
                         {
+                            "name": "selectRemoteTwo",
+                            "component": "Select",
+                            "componentAttributes": {
+                                "translateLabels": true,
+                                "options": {
+                                    "scope": "remote",
+                                    "searchParam": "term",
+                                    "endpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "initialValuesEndpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "initialValuesFilterName": "id",
+                                    "initialValuesPathParam": "name",
+                                    "valuesMapper": {
+                                        "label": {
+                                            "template": "{0} {1} - ({2})",
+                                            "fields": [
+                                                "firstname",
+                                                "lastname",
+                                                "email"
+                                            ]
+                                        },
+                                        "value": "id"
+                                    }
+                                }
+                            }
+                        },
+                        {
                             "name": "dateTime",
                             "component": "DateTimePicker",
                             "componentAttributes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-968

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe modificar el validador de schemas para que admita que la propiedad label del objeto valuesMapper acepte:

a) Un string (comportamiento actual)
b) Un objeto con las siguientes props:

**template**: Un string con el template
**fields**: Un array de fields a utilizar para reemplazar en el template

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se cambio la property label de valuesMapper de los selects de filtros y select de edit/create para que tenga mas tipos de value.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README