### PR TITLE
add new endpoint parameters in actions

### DIFF
--- a/lib/schemas/common/actions/action.js
+++ b/lib/schemas/common/actions/action.js
@@ -1,9 +1,18 @@
 'use strict';
 
+const getStaticFilters = require('../staticFilters');
+
+const newEndpointParameters = getStaticFilters();
+
 const endpointParameters = {
-	type: 'object',
-	propertyNames: { type: 'string' },
-	additionalProperties: { type: 'string' }
+	oneOf: [
+		{
+			type: 'object',
+			propertyNames: { type: 'string' },
+			additionalProperties: { type: 'string' }
+		},
+		newEndpointParameters
+	]
 };
 
 module.exports = {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -369,6 +369,53 @@
             "componentAttributes": {
                 "actionsData": [
                     {
+                        "name": "testAction",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "endpoint",
+                        "options": {
+                            "endpoint": {
+                                "service": "sac",
+                                "namespace": "claim",
+                                "method": "get",
+                                "resolve": false
+                            },
+                            "endpointParameters": {
+                                "id": "id"
+                            }
+                        }
+                    },
+                    {
+                        "name": "testAction2",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "endpoint",
+                        "options": {
+                            "endpoint": {
+                                "service": "sac",
+                                "namespace": "claim",
+                                "method": "get",
+                                "resolve": false
+                            },
+                            "endpointParameters": [
+                                {
+                                    "name": "status",
+                                    "target": "path",
+                                    "value": {
+                                        "dynamic": "id"
+                                    }
+                                },
+                                {
+                                    "name": "status",
+                                    "target": "query",
+                                    "value": {
+                                        "static": 1
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
                         "name": "new",
                         "icon": "star_light",
                         "color": "fizzGreen",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -47,6 +47,40 @@ sections:
           type: link
           options:
             path: /service/namespace/new
+
+        - name: testAction
+          icon: star_light
+          color: fizzGreen
+          type: endpoint
+          options:
+            endpoint:
+              service: sac
+              namespace: claim
+              method: get
+              resolve: false
+            endpointParameters:
+              id: id
+
+        - name: testAction2
+          icon: star_light
+          color: fizzGreen
+          type: endpoint
+          options:
+            endpoint:
+              service: sac
+              namespace: claim
+              method: get
+              resolve: false
+            endpointParameters:
+              - name: status
+                target: path
+                value:
+                  dynamic: id
+              - name: status
+                target: query
+                value:
+                  static: 1
+
   fieldsGroup:
   - name: detail
     position: left

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -533,6 +533,53 @@
             "componentAttributes": {
                 "actionsData": [
                     {
+                        "name": "testAction",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "endpoint",
+                        "options": {
+                            "endpoint": {
+                                "service": "sac",
+                                "namespace": "claim",
+                                "method": "get",
+                                "resolve": false
+                            },
+                            "endpointParameters": {
+                                "id": "id"
+                            }
+                        }
+                    },
+                    {
+                        "name": "testAction2",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "endpoint",
+                        "options": {
+                            "endpoint": {
+                                "service": "sac",
+                                "namespace": "claim",
+                                "method": "get",
+                                "resolve": false
+                            },
+                            "endpointParameters": [
+                                {
+                                    "name": "status",
+                                    "target": "path",
+                                    "value": {
+                                        "dynamic": "id"
+                                    }
+                                },
+                                {
+                                    "name": "status",
+                                    "target": "query",
+                                    "value": {
+                                        "static": 1
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
                         "name": "new",
                         "icon": "star_light",
                         "color": "fizzGreen",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -533,6 +533,53 @@
             "componentAttributes": {
                 "actionsData": [
                     {
+                        "name": "testAction",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "endpoint",
+                        "options": {
+                            "endpoint": {
+                                "service": "sac",
+                                "namespace": "claim",
+                                "method": "get",
+                                "resolve": false
+                            },
+                            "endpointParameters": {
+                                "id": "id"
+                            }
+                        }
+                    },
+                    {
+                        "name": "testAction2",
+                        "icon": "star_light",
+                        "color": "fizzGreen",
+                        "type": "endpoint",
+                        "options": {
+                            "endpoint": {
+                                "service": "sac",
+                                "namespace": "claim",
+                                "method": "get",
+                                "resolve": false
+                            },
+                            "endpointParameters": [
+                                {
+                                    "name": "status",
+                                    "target": "path",
+                                    "value": {
+                                        "dynamic": "id"
+                                    }
+                                },
+                                {
+                                    "name": "status",
+                                    "target": "query",
+                                    "value": {
+                                        "static": 1
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
                         "name": "new",
                         "icon": "star_light",
                         "color": "fizzGreen",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -77,6 +77,53 @@
                             "options": {
                                 "path": "/service/namespace/new"
                             }
+                        },
+                        {
+                            "name": "testAction",
+                            "icon": "star_light",
+                            "color": "fizzGreen",
+                            "type": "endpoint",
+                            "options": {
+                                "endpoint": {
+                                    "service": "sac",
+                                    "namespace": "claim",
+                                    "method": "get",
+                                    "resolve": false
+                                },
+                                "endpointParameters": {
+                                    "id": "id"
+                                }
+                            }
+                        },
+                        {
+                            "name": "testAction2",
+                            "icon": "star_light",
+                            "color": "fizzGreen",
+                            "type": "endpoint",
+                            "options": {
+                                "endpoint": {
+                                    "service": "sac",
+                                    "namespace": "claim",
+                                    "method": "get",
+                                    "resolve": false
+                                },
+                                "endpointParameters": [
+                                    {
+                                        "name": "status",
+                                        "target": "path",
+                                        "value": {
+                                            "dynamic": "id"
+                                        }
+                                    },
+                                    {
+                                        "name": "status",
+                                        "target": "query",
+                                        "value": {
+                                            "static": 1
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1038

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar la validación de endpointParameters como array de StaticFilters, manteniendo la validación vieja también (un objeto key-value) para mantener la retrocompatibilidad.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se cambio la prop de endpointParameters de las actions para que acepte un nuevo tipo de schemas y tambien se pueda usar el viejo.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README