### PR TITLE
add new prop for browses

### DIFF
--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -23,6 +23,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		canEdit: { type: 'boolean', default: true },
 		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },
+		canExport: { type: 'boolean', default: false },
 		themes,
 		filters,
 		sortableFields,

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -2,6 +2,7 @@
     "service": "sac",
     "name": "claim-type-browse",
     "root": "Browse",
+    "canExport": true,
     "source": {
         "service": "sac",
         "namespace": "claim-type",

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -812,6 +812,7 @@
     "hasPreview": false,
     "canEdit": true,
     "canCreate": true,
+    "canExport": true,
     "canView": false,
     "pageSize": 60
 }

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -812,6 +812,7 @@
     "hasPreview": false,
     "canEdit": true,
     "canCreate": true,
+    "canExport": true,
     "canView": false,
     "pageSize": 60,
     "actions": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -885,6 +885,7 @@
             "hasPreview": false,
             "canEdit": true,
             "canCreate": true,
+            "canExport": false,
             "canView": false,
             "pageSize": 60
         },


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1062

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe validar una nueva propiedad canExport en todos los listados (páginas o secciones)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego la prop canExport boolean al schema base de browse

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README