### PR TITLE
add new props for selects

### DIFF
--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -7,6 +7,7 @@ module.exports = makeComponent({
 	properties: {
 		translateLabels: { type: 'boolean', default: true },
 		labelPrefix: { type: 'string' },
+		canClear: { type: 'boolean' },
 		options: {
 			oneOf: [
 				{

--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -9,6 +9,7 @@ module.exports = makeComponent({
 	properties: {
 		translateLabels: { type: 'boolean' },
 		labelPrefix: { type: 'string' },
+		canClear: { type: 'boolean' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -12,6 +12,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		labelPrefix: { type: 'string' },
 		labelFieldName: { type: 'string' },
+		canClear: { type: 'boolean' },
 		options: {
 			type: 'object',
 			properties: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -62,6 +62,7 @@
             "component": "Select",
             "componentAttributes": {
                 "translateLabels": true,
+                "canClear": true,
                 "options": {
                     "scope": "local",
                     "values": [

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -295,6 +295,7 @@ sections:
           - - name: required
         componentAttributes:
           translateLabels: true
+          canClear: true
           options:
             scope: local
             values:

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -64,6 +64,7 @@
             "component": "Select",
             "componentAttributes": {
                 "translateLabels": true,
+                "canClear": true,
                 "options": {
                     "scope": "local",
                     "values": [

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -64,6 +64,7 @@
             "component": "Select",
             "componentAttributes": {
                 "translateLabels": true,
+                "canClear": true,
                 "options": {
                     "scope": "local",
                     "values": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -503,6 +503,7 @@
                             ],
                             "componentAttributes": {
                                 "translateLabels": true,
+                                "canClear": true,
                                 "options": {
                                     "scope": "local",
                                     "values": [


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1063

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar una propiedad canClear dentro de los componentAttributes de los Selects y Multiselects. Es un booleano, opcional y sin default.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego una prop a los schemas de los selects y multiselects de los browses y forms.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README