### PR TITLE
add new propeties for chip component

### DIFF
--- a/lib/schemas/browse/modules/components/chips.js
+++ b/lib/schemas/browse/modules/components/chips.js
@@ -36,6 +36,8 @@ const chipComponents = [
 		properties: {
 			icon: { type: 'string' },
 			iconColor: { type: 'string' },
+			textColor: { type: 'string' },
+			backgroundColor: { type: 'string' },
 			borderColor: { type: 'string', default: 'grey' }
 		}
 	},

--- a/lib/schemas/edit-new/modules/components/chips.js
+++ b/lib/schemas/edit-new/modules/components/chips.js
@@ -27,6 +27,8 @@ const chipComponents = [
 		properties: {
 			icon: { type: 'string' },
 			iconColor: { type: 'string' },
+			textColor: { type: 'string' },
+			backgroundColor: { type: 'string' },
 			borderColor: { type: 'string', default: 'grey' }
 		}
 	}

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -158,6 +158,12 @@ sections:
         - - name: required
     - name: test
       component: Chip
+      componentAttributes:
+        icon: icon_test
+        iconColor: red
+        borderColor: red
+        textColor: grey
+        backgroundColor: grey
     - name: user1
       component: UserChip
     - name: user2
@@ -443,6 +449,8 @@ sections:
         icon: icon_test
         iconColor: red
         borderColor: red
+        textColor: grey
+        backgroundColor: grey
     - name: rangeHigh
       component: Chip
 

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -284,7 +284,11 @@
                             "name": "test",
                             "component": "Chip",
                             "componentAttributes": {
-                                "borderColor": "grey"
+                                "icon": "icon_test",
+                                "iconColor": "red",
+                                "borderColor": "red",
+                                "textColor": "grey",
+                                "backgroundColor": "grey"
                             }
                         },
                         {
@@ -766,7 +770,9 @@
                     "componentAttributes": {
                         "icon": "icon_test",
                         "iconColor": "red",
-                        "borderColor": "red"
+                        "borderColor": "red",
+                        "textColor": "grey",
+                        "backgroundColor": "grey"
                     }
                 },
                 {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1064

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe poder configurar, además de los componentAttributes actuales los siguientes (todos strings opcionales)
- textColor
- backgroundColor

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron nuevas props al schemas de Chip de Browses y Forms

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README