### PR TITLE
add action with callback in top sections

### DIFF
--- a/lib/schemas/edit-new/modules/sections/components/topComponents.js
+++ b/lib/schemas/edit-new/modules/sections/components/topComponents.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const actions = require('../../../../common/actions');
+const action = require('../../../../common/actions/action');
 
 const commonProperties = {
 	position: {
@@ -13,6 +13,19 @@ const commonProperties = {
 	}
 };
 
+const availableCallbacks = ['reloadSectionData', 'refresh'];
+
+const customAction = {
+	...action,
+	properties: {
+		...action.properties,
+		callback: {
+			enum: availableCallbacks
+		}
+	}
+};
+
+
 module.exports = {
 	type: 'array',
 	items: {
@@ -24,7 +37,10 @@ module.exports = {
 		},
 		then: {
 			properties: {
-				actions,
+				actions: {
+					type: 'array',
+					items: customAction
+				},
 				...commonProperties
 			},
 			required: ['actions', 'component']

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -52,6 +52,7 @@ sections:
           icon: star_light
           color: fizzGreen
           type: endpoint
+          callback: reloadSectionData
           options:
             endpoint:
               service: sac
@@ -65,6 +66,7 @@ sections:
           icon: star_light
           color: fizzGreen
           type: endpoint
+          callback: refresh
           options:
             endpoint:
               service: sac

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -83,6 +83,7 @@
                             "icon": "star_light",
                             "color": "fizzGreen",
                             "type": "endpoint",
+                            "callback": "reloadSectionData",
                             "options": {
                                 "endpoint": {
                                     "service": "sac",
@@ -100,6 +101,7 @@
                             "icon": "star_light",
                             "color": "fizzGreen",
                             "type": "endpoint",
+                            "callback": "refresh",
                             "options": {
                                 "endpoint": {
                                     "service": "sac",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1082

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deben validar la opción de poner callbacks, igual que se hizo en los ActionButtons de listados.
Los callbacks válidos son _reloadSectionData_ y _refresh_.

Solo aplican a las ActionButtons que sean de tipo endpoint (no a las de tipo link)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron nuevas props a los action buttons de los top componets de los edits/create

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README