### PR TITLE
add header edit new props

### DIFF
--- a/lib/schemas/edit-new/modules/headerProperties.js
+++ b/lib/schemas/edit-new/modules/headerProperties.js
@@ -29,7 +29,27 @@ module.exports = {
 			type: 'object',
 			properties: {
 				afterId: commonAfterBefore,
-				beforeId: commonAfterBefore
+				beforeId: commonAfterBefore,
+				identifier: {
+					oneOf: [
+						{ type: 'string' },
+						{
+							type: 'object',
+							properties: {
+								template: { type: 'string' },
+								fields: {
+									type: 'array',
+									items: {
+										type: 'string'
+									},
+									minItems: 1
+								}
+							},
+							required: ['template', 'fields'],
+							additionalProperties: false
+						}
+					]
+				}
 			},
 			minProperties: 1,
 			additionalProperties: false

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -21,6 +21,13 @@ header:
         component: StatusChip
         componentAttributes:
           useTheme: themeOne
+    identifier:
+      template: '{0} {1} - ({2})'
+      fields:
+        - test1
+        - test2
+        - test3
+
 themes:
   themeOne:
     new: black

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -35,7 +35,15 @@
                         "useTheme": "themeOne"
                     }
                 }
-            ]
+            ],
+            "identifier": {
+                "template": "{0} {1} - ({2})",
+                "fields": [
+                    "test1",
+                    "test2",
+                    "test3"
+                ]
+            }
         }
     },
     "themes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1064

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe validar una nueva propiedad opcional identifier. Con dos opciones de configuración:
string representando el nombre de una propiedad de la data del edit
object con las propiedades template y fields. Funciona igual que los labels de los selectores.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego una nueva prop al schema de componente de header de edit de identifier con las props descriptas arriba.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README