### PR TITLE
add canCreate prop in edit create schema

### DIFF
--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -21,6 +21,7 @@ module.exports = {
 			$ref: 'schemaDefinitions#/definitions/endpoint'
 		},
 		root: { enum: ['Edit', 'Create'] },
+		canCreate: { type: 'boolean' },
 		header,
 		sections: {
 			type: 'array',

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1,6 +1,7 @@
 service: sac
 name: claim-motive-edit
 root: Edit
+canCreate: true
 source:
   service: sac
   namespace: claim-motive

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -2,6 +2,7 @@
     "service": "sac",
     "name": "claim-motive-edit",
     "root": "Edit",
+    "canCreate": true,
     "source": {
         "service": "sac",
         "namespace": "claim-motive",

--- a/tests/mocks/schemas/new.yml
+++ b/tests/mocks/schemas/new.yml
@@ -1,6 +1,7 @@
 service: sac
 name: claim-motive-new
 root: Create
+canCreate: false
 target:
   service: sac
   namespace: claim-motive


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1119

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar una nueva propiedad canCreate al schema de edit/create, sea opcional boolean.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego una nueva prop boolean opcional al schema de edit/create

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README