### PR TITLE
validate schemas select multilevel

### DIFF
--- a/lib/schemas/edit-new/modules/componentNames.js
+++ b/lib/schemas/edit-new/modules/componentNames.js
@@ -7,6 +7,7 @@ module.exports = {
 	link: 'Link',
 	select: 'Select',
 	multiselect: 'Multiselect',
+	selectMultilevel: 'SelectMultilevel',
 	switch: 'Switch',
 	text: 'Text',
 	textarea: 'Textarea',

--- a/lib/schemas/edit-new/modules/components/index.js
+++ b/lib/schemas/edit-new/modules/components/index.js
@@ -11,11 +11,13 @@ const link = require('./link');
 const fieldsArray = require('./fieldsArray');
 const checkList = require('./checkList');
 const asyncWrapper = require('./asyncWrapper');
+const selectMultilevel = require('./selectMultilevel');
 const map = require('./map');
 const html = require('./html');
 
 module.exports = [
 	selects,
+	selectMultilevel,
 	input,
 	multiInput,
 	code,

--- a/lib/schemas/edit-new/modules/components/selectMultilevel.js
+++ b/lib/schemas/edit-new/modules/components/selectMultilevel.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const componentsNames = require('../componentNames');
+const options = require('../options');
+
+const { selectMultilevel } = componentsNames;
+
+module.exports = makeComponent({
+	name: selectMultilevel,
+	properties: {
+		translateLabels: { type: 'boolean' },
+		maxLevel: { type: 'number' },
+		parentFilterName: { type: 'string' },
+		labelPrefix: { type: 'string' },
+		labelFieldName: { type: 'string' },
+		canClear: { type: 'boolean' },
+		options: {
+			type: 'object',
+			properties: {
+				scope: { const: 'remote' }
+			},
+			allOf: options
+		}
+	},
+	requiredProperties: ['translateLabels', 'parentFilterName']
+});

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -398,6 +398,39 @@ sections:
                  - email
               value: id
 
+      - name: selectMultilevelExample
+        component: SelectMultilevel
+        componentAttributes:
+          translateLabels: true
+          parentFilterName: parent
+          maxLevel: 3
+          options:
+            scope: remote
+            endpoint:
+              service: sac
+              namespace: claim
+              method: list
+              resolve: false
+            initialValuesEndpoint:
+              service: sac
+              namespace: claim
+              method: list
+              resolve: false
+            initialValuesFilterName: id
+            initialValuesPathParam: name
+            endpointParameters:
+              - name: status
+                target: path
+                value:
+                  dynamic: id
+              - name: status
+                target: query
+                value:
+                  static: 1
+            valuesMapper:
+              label: name
+              value: id
+
       - name: dateTime
         component: DateTimePicker
         componentAttributes:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -653,6 +653,53 @@
                             }
                         },
                         {
+                            "name": "selectMultilevelExample",
+                            "component": "SelectMultilevel",
+                            "componentAttributes": {
+                                "translateLabels": true,
+                                "parentFilterName": "parent",
+                                "maxLevel": 3,
+                                "options": {
+                                    "scope": "remote",
+                                    "searchParam": "term",
+                                    "endpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "initialValuesEndpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "initialValuesFilterName": "id",
+                                    "initialValuesPathParam": "name",
+                                    "endpointParameters": [
+                                        {
+                                            "name": "status",
+                                            "target": "path",
+                                            "value": {
+                                                "dynamic": "id"
+                                            }
+                                        },
+                                        {
+                                            "name": "status",
+                                            "target": "query",
+                                            "value": {
+                                                "static": 1
+                                            }
+                                        }
+                                    ],
+                                    "valuesMapper": {
+                                        "label": "name",
+                                        "value": "id"
+                                    }
+                                }
+                            }
+                        },
+                        {
                             "name": "dateTime",
                             "component": "DateTimePicker",
                             "componentAttributes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1156

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar un nuevo schema para un nuevo component en edit/create (SelectMultilevel)

Properties iguales a las del Select remoto

mas unas props nuevas
- parentFilterName(string-required)
- maxLevel(number-optional)

 

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego un nuevo componente con las mismas props de un Select remoto y  con props adicionales.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README