### PR TITLE
add new prop canRefresh in browses

### DIFF
--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -24,6 +24,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },
 		canExport: { type: 'boolean', default: false },
+		canRefresh: { type: 'boolean' },
 		themes,
 		filters,
 		sortableFields,

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -3,6 +3,7 @@
     "name": "claim-type-browse",
     "root": "Browse",
     "canExport": true,
+    "canRefresh": false,
     "source": {
         "service": "sac",
         "namespace": "claim-type",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -431,6 +431,7 @@ sections:
 
 - name: semaphoreBrowse
   rootComponent: BrowseSection
+  canRefresh: true
   topComponents:
     - component: TestComponent
       attributes:

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -818,5 +818,6 @@
     "canCreate": true,
     "canExport": true,
     "canView": false,
+    "canRefresh": false,
     "pageSize": 60
 }

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -818,6 +818,7 @@
     "canCreate": true,
     "canExport": true,
     "canView": false,
+    "canRefresh": false,
     "pageSize": 60,
     "actions": [
         {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -700,6 +700,7 @@
         {
             "name": "semaphoreBrowse",
             "rootComponent": "BrowseSection",
+            "canRefresh": true,
             "source": {
                 "service": "sac",
                 "namespace": "claim-semaphore",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1159

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar un nueva prop a los Browses para poder refrescar un listado.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego una nueva prop de canRefresh en todos los browses, boolean y opcional

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README