### PR TITLE
Jmv 1203 reorder browse prop

### DIFF
--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -10,10 +10,7 @@ module.exports = {
 		...properties,
 		...getBrowseBaseSchema(true),
 		root: { const: 'Browse' },
-		actions,
-		source: {
-			$ref: 'schemaDefinitions#/definitions/endpoint'
-		}
+		actions
 	},
 	additionalProperties: false,
 	required: [...required, 'fields', 'source']

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -34,6 +34,7 @@ const makeAppearance = () => {
 
 const getBrowseBaseSchema = (isPage = false) => {
 	return {
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		fields: {
 			type: 'array',
 			items: {
@@ -41,6 +42,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 			},
 			minItems: 1
 		},
+		sortEndpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		staticFilters: getStaticFilters(isPage),
 		hasPreview: { type: 'boolean', default: false },
 		canEdit: { type: 'boolean', default: true },

--- a/lib/schemas/edit-new/modules/sections/browseSection.js
+++ b/lib/schemas/edit-new/modules/sections/browseSection.js
@@ -14,10 +14,7 @@ module.exports = {
 			...getBrowseBaseSchema(),
 			title: { type: 'string' },
 			name: { type: 'string' },
-			rootComponent: { type: 'string', const: browseSection },
-			source: {
-				$ref: 'schemaDefinitions#/definitions/endpoint'
-			}
+			rootComponent: { type: 'string', const: browseSection }
 		},
 		required: ['name', 'rootComponent', 'source', 'fields'],
 		additionalProperties: false

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -10,6 +10,12 @@
         "method": "browse",
         "resolve": false
     },
+    "sortEndpoint": {
+        "service": "service",
+        "namespace": "namespace",
+        "method": "method",
+        "resolve": false
+    },
     "appearance": {
         "desktop": {
             "rowMinHeight": 70,

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -489,6 +489,11 @@ sections:
     namespace: claim-semaphore
     method: browse
     resolve: false
+  sortEndpoint:
+    service: service
+    namespace: namespace
+    method: method
+    resolve: false
   appearance:
     default:
       rowMinHeight: 50

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -8,6 +8,12 @@
         "method": "browse",
         "resolve": false
     },
+    "sortEndpoint": {
+        "service": "service",
+        "namespace": "namespace",
+        "method": "method",
+        "resolve": false
+    },
     "appearance": {
         "desktop": {
             "rowMinHeight": 70,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -8,6 +8,12 @@
         "method": "browse",
         "resolve": false
     },
+    "sortEndpoint": {
+        "service": "service",
+        "namespace": "namespace",
+        "method": "method",
+        "resolve": false
+    },
     "appearance": {
         "desktop": {
             "rowMinHeight": 70,

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -767,6 +767,12 @@
                 "method": "browse",
                 "resolve": false
             },
+            "sortEndpoint":{
+                "service": "service",
+                "namespace": "namespace",
+                "method": "method",
+                "resolve": false
+            },
             "appearance": {
                 "default": {
                     "rowMinHeight": 50


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1203

**DESCRIPCIÓN DEL REQUERIMIENTO**

Agregar una nueva prop a los browse para que puedan ser reordenable.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó una prop nueva al schema de browse llamada sortEndpoint que indique el endpoint para reordenar el listado.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README