### PR TITLE
add icon prop in selects and input componenets in edit/create and browse

### DIFF
--- a/lib/schemas/browse/modules/filters/components/input.js
+++ b/lib/schemas/browse/modules/filters/components/input.js
@@ -1,12 +1,11 @@
 'use strict';
 
+const { makeComponent } = require('../../../../utils');
 const { input } = require('../componentNames');
 
-module.exports = {
-	if: {
-		properties: {
-			component: { const: input }
-		}
-	},
-	then: { type: 'object' }
-};
+module.exports = makeComponent({
+	name: input,
+	properties: {
+		icon: { type: 'string' }
+	}
+});

--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -10,6 +10,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		labelPrefix: { type: 'string' },
 		canClear: { type: 'boolean' },
+		icon: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -6,6 +6,7 @@ const { input } = require('../componentNames');
 module.exports = makeComponent({
 	name: input,
 	properties: {
+		icon: { type: 'string' },
 		type: { enum: ['text', 'number', 'email', 'password'] }
 	}
 });

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -13,6 +13,7 @@ module.exports = makeComponent({
 		labelPrefix: { type: 'string' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },
+		icon: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -63,7 +63,10 @@
         {
             "name": "filterInput",
             "label": "test.test.test",
-            "component": "Input"
+            "component": "Input",
+            "componentAttributes": {
+                "icon": "iconName"
+            }
         },
         {
             "name": "localSelect",
@@ -71,6 +74,7 @@
             "componentAttributes": {
                 "translateLabels": true,
                 "canClear": true,
+                "icon": "iconName",
                 "options": {
                     "scope": "local",
                     "values": [

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -108,6 +108,7 @@ sections:
         translateLabels: true
         labelFieldName: motiveName
         labelPrefix: common.status.
+        icon: iconName
         options:
           scope: local
           valuesMapper:
@@ -302,6 +303,11 @@ sections:
             resolve: false
           dataMapping:
             name: firstname
+
+    - name: someInput
+      component: Input
+      componentAttributes:
+        icon: iconName
 
     - name: fieldsArray
       component: FieldsArray

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -63,7 +63,9 @@
             "name": "filterInput",
             "label": "test.test.test",
             "component": "Input",
-            "componentAttributes": {}
+            "componentAttributes": {
+                "icon": "iconName"
+            }
         },
         {
             "name": "localSelect",
@@ -71,6 +73,7 @@
             "componentAttributes": {
                 "translateLabels": true,
                 "canClear": true,
+                "icon": "iconName",
                 "options": {
                     "scope": "local",
                     "values": [

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -63,7 +63,9 @@
             "name": "filterInput",
             "label": "test.test.test",
             "component": "Input",
-            "componentAttributes": {}
+            "componentAttributes": {
+                "icon": "iconName"
+            }
         },
         {
             "name": "localSelect",
@@ -71,6 +73,7 @@
             "componentAttributes": {
                 "translateLabels": true,
                 "canClear": true,
+                "icon": "iconName",
                 "options": {
                     "scope": "local",
                     "values": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -157,6 +157,7 @@
                                 "translateLabels": true,
                                 "labelFieldName": "motiveName",
                                 "labelPrefix": "common.status.",
+                                "icon": "iconName",
                                 "options": {
                                     "scope": "local",
                                     "valuesMapper": {
@@ -499,6 +500,13 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "name": "someInput",
+                            "component": "Input",
+                            "componentAttributes": {
+                                "icon": "iconName"
+                            }
                         },
                         {
                             "name": "fieldsArray",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1208

**DESCRIPCIÓN DEL REQUERIMIENTO**

Agregar componentAttribute icon como un string opcional en:
Selects y Input de edit/create y en filtros de browse

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron en los schemas de select y input de edit/create y browse, la prop de icon

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README