### PR TITLE
Jmv 1199 fields iteractions

### DIFF
--- a/lib/schemas/browse/modules/field.js
+++ b/lib/schemas/browse/modules/field.js
@@ -4,6 +4,7 @@ const componentNames = require('./componentNames');
 const components = require('./components');
 const mapper = require('../../common/mapper');
 const makeConditions = require('../../common/conditions');
+const interactions = require('./interactions');
 const filter = require('./filter');
 
 module.exports = {
@@ -35,7 +36,8 @@ module.exports = {
 		},
 		mapper,
 		filter,
-		conditions: makeConditions(false)
+		conditions: makeConditions(false),
+		...interactions
 	},
 	allOf: components,
 	additionalProperties: false,

--- a/lib/schemas/browse/modules/interactions.js
+++ b/lib/schemas/browse/modules/interactions.js
@@ -45,32 +45,26 @@ const interactionComponents = [
 	}
 ];
 
-const interactionProperties = {
-	desktop: {
+const interactionProperties = () => {
+	const props = {
 		type: 'object',
-		allOf: interactionComponents
-	},
-	mobile: {
+		oneof: interactionComponents
+	};
+
+	return {
 		type: 'object',
-		allOf: interactionComponents
-	},
-	all: {
-		type: 'object',
-		allOf: interactionComponents
-	}
+		properties: {
+			desktop: props,
+			mobile: props,
+			all: props
+		},
+		additionalProperties: false
+	};
 };
 
 const interactions = {
-	onHover: {
-		type: 'object',
-		properties: interactionProperties,
-		additionalProperties: false
-	},
-	onClick: {
-		type: 'object',
-		properties: interactionProperties,
-		additionalProperties: false
-	}
+	onHover: interactionProperties(),
+	onClick: interactionProperties()
 };
 
 module.exports = interactions;

--- a/lib/schemas/browse/modules/interactions.js
+++ b/lib/schemas/browse/modules/interactions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getStaticFilters = require('../../common/staticFilters');
+const mapper = require('../../common/mapper');
 
 const interactionComponents = [
 	{
@@ -13,7 +14,8 @@ const interactionComponents = [
 			properties: {
 				type: { const: 'Tooltip' },
 				label: { type: 'string' },
-				translateLabels: { type: 'boolean' }
+				translateLabels: { type: 'boolean' },
+				mapper
 			},
 			additionalProperties: false,
 			required: ['label']
@@ -48,7 +50,7 @@ const interactionComponents = [
 const interactionProperties = () => {
 	const props = {
 		type: 'object',
-		oneof: interactionComponents
+		allOf: interactionComponents
 	};
 
 	return {

--- a/lib/schemas/browse/modules/interactions.js
+++ b/lib/schemas/browse/modules/interactions.js
@@ -2,20 +2,6 @@
 
 const getStaticFilters = require('../../common/staticFilters');
 
-const listComponentProperties = {
-	type: { enum: ['ListTooltip', 'ListModal'] },
-	source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-	translateLabels: { type: 'boolean' },
-	title: { type: 'string' },
-	listFields: {
-		type: 'array',
-		items: { type: 'string' },
-		minItems: 1
-	},
-	viewMoreLink: { type: 'string' },
-	viewMoreEndpointParameters: getStaticFilters()
-};
-
 const interactionComponents = [
 	{
 		if: {
@@ -40,7 +26,19 @@ const interactionComponents = [
 			}
 		},
 		then: {
-			properties: listComponentProperties,
+			properties: {
+				type: { enum: ['ListTooltip', 'ListModal'] },
+				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+				translateLabels: { type: 'boolean' },
+				title: { type: 'string' },
+				listFields: {
+					type: 'array',
+					items: { type: 'string' },
+					minItems: 1
+				},
+				viewMoreLink: { type: 'string' },
+				viewMoreEndpointParameters: getStaticFilters()
+			},
 			additionalProperties: false,
 			required: ['source', 'listFields', 'title']
 		}

--- a/lib/schemas/browse/modules/interactions.js
+++ b/lib/schemas/browse/modules/interactions.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const getStaticFilters = require('../../common/staticFilters');
+
+const listComponentProperties = {
+	type: { enum: ['ListTooltip', 'ListModal'] },
+	source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+	translateLabels: { type: 'boolean' },
+	title: { type: 'string' },
+	listFields: {
+		type: 'array',
+		items: { type: 'string' },
+		minItems: 1
+	},
+	viewMoreLink: { type: 'string' },
+	viewMoreEndpointParameters: getStaticFilters()
+};
+
+const interactionComponents = [
+	{
+		if: {
+			properties: {
+				type: { const: 'Tooltip' }
+			}
+		},
+		then: {
+			properties: {
+				type: { const: 'Tooltip' },
+				label: { type: 'string' },
+				translateLabels: { type: 'boolean' }
+			},
+			additionalProperties: false,
+			required: ['label']
+		}
+	},
+	{
+		if: {
+			properties: {
+				type: { enum: ['ListTooltip', 'ListModal'] }
+			}
+		},
+		then: {
+			properties: listComponentProperties,
+			additionalProperties: false,
+			required: ['source', 'listFields', 'title']
+		}
+	}
+];
+
+const interactionProperties = {
+	desktop: {
+		type: 'object',
+		allOf: interactionComponents
+	},
+	mobile: {
+		type: 'object',
+		allOf: interactionComponents
+	},
+	all: {
+		type: 'object',
+		allOf: interactionComponents
+	}
+};
+
+const interactions = {
+	onHover: {
+		type: 'object',
+		properties: interactionProperties,
+		additionalProperties: false
+	},
+	onClick: {
+		type: 'object',
+		properties: interactionProperties,
+		additionalProperties: false
+	}
+};
+
+module.exports = interactions;

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -599,6 +599,102 @@
                     ]
                 ]
             }
+        },
+        {
+            "name": "interactionExampleOne",
+            "component": "Text",
+            "onHover": {
+                "mobile": {
+                    "type": "ListTooltip",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                },
+                "desktop": {
+                    "type": "Tooltip",
+                    "label": "common.title",
+                    "translateLabels": true
+                }
+            },
+            "onClick": {
+                "mobile": {
+                    "type": "ListTooltip",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                },
+                "desktop": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                }
+            }
+        },
+        {
+            "name": "interactionExampleTwo",
+            "component": "Text",
+            "onHover": {
+                "all": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"],
+                    "viewMoreLink": "/test/{id}",
+                    "viewMoreEndpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ]
+                }
+            },
+            "onClick": {
+                "all": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"],
+                    "viewMoreLink": "/test/{id}",
+                    "viewMoreEndpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ]
+                }
+            }
         }
     ]
 }

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -618,7 +618,13 @@
                 "desktop": {
                     "type": "Tooltip",
                     "label": "common.title",
-                    "translateLabels": true
+                    "translateLabels": true,
+                    "mapper": {
+                        "name": "suffix",
+                        "props":{
+                            "value": "comon.test."
+                        }
+                    }
                 }
             },
             "onClick": {
@@ -673,6 +679,25 @@
                 }
             },
             "onClick": {
+                "desktop": {
+                    "type": "Tooltip",
+                    "label": "common.title",
+                    "translateLabels": true,
+                    "mapper": [
+                        {
+                            "name": "suffix",
+                            "props":{
+                                "value": "comon.test."
+                            }
+                        },
+                        {
+                            "name": "prefix",
+                            "props":{
+                                "value": "comon.test."
+                            }
+                        }
+                    ]
+                },
                 "all": {
                     "type": "ListModal",
                     "title": "common.title",

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -877,7 +877,13 @@
                 "desktop": {
                     "type": "Tooltip",
                     "label": "common.title",
-                    "translateLabels": true
+                    "translateLabels": true,
+                    "mapper": {
+                        "name": "suffix",
+                        "props":{
+                            "value": "comon.test."
+                        }
+                    }
                 }
             },
             "onClick": {
@@ -941,6 +947,25 @@
                 }
             },
             "onClick": {
+                "desktop": {
+                    "type": "Tooltip",
+                    "label": "common.title",
+                    "translateLabels": true,
+                    "mapper": [
+                        {
+                            "name": "suffix",
+                            "props":{
+                                "value": "comon.test."
+                            }
+                        },
+                        {
+                            "name": "prefix",
+                            "props":{
+                                "value": "comon.test."
+                            }
+                        }
+                    ]
+                },
                 "all": {
                     "type": "ListModal",
                     "title": "common.title",

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -852,6 +852,120 @@
                     ]
                 ]
             }
+        },
+        {
+            "name": "interactionExampleOne",
+            "component": "Text",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "onHover": {
+                "mobile": {
+                    "type": "ListTooltip",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                },
+                "desktop": {
+                    "type": "Tooltip",
+                    "label": "common.title",
+                    "translateLabels": true
+                }
+            },
+            "onClick": {
+                "mobile": {
+                    "type": "ListTooltip",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                },
+                "desktop": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                }
+            },
+            "componentAttributes": {
+                "fontWeight": "normal"
+            }
+        },
+        {
+            "name": "interactionExampleTwo",
+            "component": "Text",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "onHover": {
+                "all": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"],
+                    "viewMoreLink": "/test/{id}",
+                    "viewMoreEndpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ]
+                }
+            },
+            "onClick": {
+                "all": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"],
+                    "viewMoreLink": "/test/{id}",
+                    "viewMoreEndpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ]
+                }
+            },
+            "componentAttributes": {
+                "fontWeight": "normal"
+            }
         }
     ],
     "hasPreview": false,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -877,7 +877,13 @@
                 "desktop": {
                     "type": "Tooltip",
                     "label": "common.title",
-                    "translateLabels": true
+                    "translateLabels": true,
+                    "mapper": {
+                        "name": "suffix",
+                        "props":{
+                            "value": "comon.test."
+                        }
+                    }
                 }
             },
             "onClick": {
@@ -941,6 +947,25 @@
                 }
             },
             "onClick": {
+                "desktop": {
+                    "type": "Tooltip",
+                    "label": "common.title",
+                    "translateLabels": true,
+                    "mapper": [
+                        {
+                            "name": "suffix",
+                            "props":{
+                                "value": "comon.test."
+                            }
+                        },
+                        {
+                            "name": "prefix",
+                            "props":{
+                                "value": "comon.test."
+                            }
+                        }
+                    ]
+                },
                 "all": {
                     "type": "ListModal",
                     "title": "common.title",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -852,6 +852,120 @@
                     ]
                 ]
             }
+        },
+        {
+            "name": "interactionExampleOne",
+            "component": "Text",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "onHover": {
+                "mobile": {
+                    "type": "ListTooltip",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                },
+                "desktop": {
+                    "type": "Tooltip",
+                    "label": "common.title",
+                    "translateLabels": true
+                }
+            },
+            "onClick": {
+                "mobile": {
+                    "type": "ListTooltip",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                },
+                "desktop": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"]
+                }
+            },
+            "componentAttributes": {
+                "fontWeight": "normal"
+            }
+        },
+        {
+            "name": "interactionExampleTwo",
+            "component": "Text",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "onHover": {
+                "all": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"],
+                    "viewMoreLink": "/test/{id}",
+                    "viewMoreEndpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ]
+                }
+            },
+            "onClick": {
+                "all": {
+                    "type": "ListModal",
+                    "title": "common.title",
+                    "source": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "listFields": ["fieldName"],
+                    "viewMoreLink": "/test/{id}",
+                    "viewMoreEndpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ]
+                }
+            },
+            "componentAttributes": {
+                "fontWeight": "normal"
+            }
         }
     ],
     "hasPreview": false,


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1211

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe poder indicar en cada campo de un Listado las interacciones que puede tener con el usuario.
Se debe poder indicar interacciones para el hover y para el click.
Debe ser configurable de manera independiente para Mobile y Desktop (por ejemplo para que en desktop algo pase en el hover, pero en mobile pase en el click)

En cada una se debe poder indicar una de las siguientes opciones de interacción:

- Tooltip (el tooltip negro con un texto)
- ListTooltip (el más grande, blanco con borde azul que muestra un listado de items)
- ListModal (no hace falta mucha aclaración para este)

Cada una de las opciones tiene su propia configuración:

Tooltip

Debe poder recibir un label fijo, o un campo de la row que tenga el valor de ese label (requerido)
Debe poder recibir un prefijo y/o un sufijo
Debe poderse indicar si se debe traducir o no
Solo aplica para el hover

ListTooltip y ListModal
- Debe poder recibir un title, traducible o no
- Debe recibir un endpoint de una API List que traiga los datos a mostrar (con endpointParameters que reemplacen con la data de la row)
- Debe recibir cuáles campos de esa API List se deben mostrar, de manera ordenada (por ahora todos textos comunes, esto seguramente cambie más adelante)
- Debe poder recibir una URL a donde se linkea un botón de “Ver todos/Ver más” al final del listado

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron nuevas properties al schema de field de browse con todo lo comentado en la descripcion.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README