### PR TITLE
add fielSortEndpoint in files sections

### DIFF
--- a/lib/schemas/edit-new/modules/sections/section-files/common.js
+++ b/lib/schemas/edit-new/modules/sections/section-files/common.js
@@ -17,6 +17,7 @@ module.exports = (sectionName, properties = {}) => ({
 			fileListEndpoint: endpoint,
 			fileDeleteEndpoint: endpoint,
 			fileGetEndpoint: endpoint,
+			fileSortEndpoint: endpoint,
 			filesTypes: {
 				type: 'array',
 				items: {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -640,6 +640,11 @@ sections:
     namespace: claim
     method: upload
     resolve: false
+  fileSortEndpoint:
+    service: sac
+    namespace: claim
+    method: sort
+    resolve: false
   filesTypes:
     - image/png
 
@@ -669,6 +674,11 @@ sections:
     service: sac
     namespace: claim
     method: upload
+    resolve: false
+  fileSortEndpoint:
+    service: sac
+    namespace: claim
+    method: sort
     resolve: false
   fileUpdateEndpoint:
     service: sac

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1103,6 +1103,12 @@
                 "method": "upload",
                 "resolve": false
             },
+            "fileSortEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "sort",
+                "resolve": false
+            },
             "filesTypes": [
                 "image/png"
             ]
@@ -1138,6 +1144,12 @@
                 "service": "sac",
                 "namespace": "claim",
                 "method": "upload",
+                "resolve": false
+            },
+            "fileSortEndpoint": {
+                "service": "sac",
+                "namespace": "claim",
+                "method": "sort",
                 "resolve": false
             },
             "fileUpdateEndpoint": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1234

**DESCRIPCIÓN DEL REQUERIMIENTO**

Agregar una nueva prop a los schemas de secciones de archivos.
nueva prop de componentAttributes
- fileSortEndpoint: sourceEnpoint - opctional

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego una nueva prop al schema de las secciones de files

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README