### PR TITLE
add collapse section props

### DIFF
--- a/lib/schemas/edit-new/modules/sections/commonProperties.js
+++ b/lib/schemas/edit-new/modules/sections/commonProperties.js
@@ -5,5 +5,6 @@ const makeConditions = require('../../../common/conditions');
 
 module.exports = {
 	topComponents,
+	collapse: { type: 'boolean' },
 	conditions: makeConditions(false)
 };

--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -25,6 +25,7 @@ module.exports = {
 		root: { enum: ['Edit', 'Create'] },
 		canCreate: { type: 'boolean' },
 		header,
+		collapseSections: { type: 'boolean' },
 		sections: {
 			type: 'array',
 			items: {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -42,6 +42,7 @@ themes:
   themeTwo:
     new: grey
     closed: fizzgreen
+collapseSections: true
 sections:
 - name: mainFormSection
   rootComponent: MainForm
@@ -724,6 +725,7 @@ sections:
 
 - name: anotherOrderItemsSection
   rootComponent: OrderItemsSection
+  collapse: false
 
 - name: apiKeysSection
   rootComponent: ApiKeysSection

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -62,6 +62,7 @@
             "closed": "fizzgreen"
         }
     },
+    "collapseSections": true,
     "sections": [
         {
             "name": "mainFormSection",
@@ -1218,7 +1219,8 @@
         },
         {
             "name": "anotherOrderItemsSection",
-            "rootComponent": "OrderItemsSection"
+            "rootComponent": "OrderItemsSection",
+            "collapse": false
         },
         {
             "name": "apiKeysSection",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1241

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe poder definir una propiedad para colapsar todas las tabs de un edit
Se debe poder definir una propiedad para colapsar/no colapsar una tab específica de un edit

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó una nueva prop a las secciones llamada `collapse` (booleana-opcional) y otra para el schema de edit/create para definir si todas las secciones son collapsables llamada `collapseSections` (booleana-opcional)

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README