### PR TITLE
add fields appearance

### DIFF
--- a/lib/schemas/browse/modules/field.js
+++ b/lib/schemas/browse/modules/field.js
@@ -7,6 +7,41 @@ const makeConditions = require('../../common/conditions');
 const interactions = require('./interactions');
 const filter = require('./filter');
 
+const makeAppearance = () => {
+	const appearanceProps = {
+		type: 'object',
+		properties: {
+			fontColor: { type: 'string' },
+			fontSize: {
+				enum: [
+					'base',
+					'baseSmall',
+					'small',
+					'xsmall',
+					'large',
+					'xlarge',
+					'xxlarge'
+				]
+			},
+			align: { enum: ['left', 'center', 'right'] },
+			verticalAlign: { enum: ['top', 'center', 'bottom'] }
+		},
+		additionalProperties: false,
+		minProperties: 1
+	};
+
+	return {
+		type: 'object',
+		properties: {
+			default: appearanceProps,
+			desktop: appearanceProps,
+			mobile: appearanceProps
+		},
+		additionalProperties: false,
+		minProperties: 1
+	};
+};
+
 module.exports = {
 	type: 'object',
 	properties: {
@@ -15,6 +50,7 @@ module.exports = {
 		label: { type: 'string' },
 		noLabel: { type: 'boolean' },
 		deviceDisplay: { enum: ['desktop', 'mobile'] },
+		appearance: makeAppearance(),
 		attributes: {
 			type: 'object',
 			properties: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -176,6 +176,24 @@
         {
             "name": "id",
             "component": "BoldText",
+            "appearance": {
+                "desktop": {
+                    "fontSize": "base",
+                    "align": "left",
+                    "verticalAlign": "center"
+                },
+                "mobile": {
+                    "fontSize": "baseSmall",
+                    "align": "center",
+                    "verticalAlign": "top"
+                },
+                "default": {
+                    "fontColor": "blue",
+                    "fontSize": "small",
+                    "align": "right",
+                    "verticalAlign": "bottom"
+                }
+            },
             "attributes": {
                 "sortable": true,
                 "isDefaultSort": true
@@ -186,6 +204,17 @@
         {
             "name": "motiveName",
             "component": "MediumText",
+            "appearance": {
+                "desktop": {
+                    "fontSize": "xsmall"
+                },
+                "mobile": {
+                    "fontSize": "large"
+                },
+                "default": {
+                    "fontSize": "xlarge"
+                }
+            },
             "deviceDisplay": "mobile",
             "filter": {
                 "component": "Input"
@@ -194,6 +223,11 @@
         {
             "name": "parentName",
             "component": "Text",
+            "appearance": {
+                "default": {
+                    "fontSize": "xxlarge"
+                }
+            },
             "mapper": {
                 "name": "suffix",
                 "props": {

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -177,6 +177,24 @@
         {
             "name": "id",
             "component": "BoldText",
+            "appearance": {
+                "desktop": {
+                    "fontSize": "base",
+                    "align": "left",
+                    "verticalAlign": "center"
+                },
+                "mobile": {
+                    "fontSize": "baseSmall",
+                    "align": "center",
+                    "verticalAlign": "top"
+                },
+                "default": {
+                    "fontColor": "blue",
+                    "fontSize": "small",
+                    "align": "right",
+                    "verticalAlign": "bottom"
+                }
+            },
             "attributes": {
                 "sortable": true,
                 "isDefaultSort": true,
@@ -192,6 +210,17 @@
         {
             "name": "motiveName",
             "component": "MediumText",
+            "appearance": {
+                "desktop": {
+                    "fontSize": "xsmall"
+                },
+                "mobile": {
+                    "fontSize": "large"
+                },
+                "default": {
+                    "fontSize": "xlarge"
+                }
+            },
             "filter": {
                 "component": "Input",
                 "type": "equal",
@@ -212,6 +241,11 @@
         {
             "name": "parentName",
             "component": "Text",
+            "appearance": {
+                "default": {
+                    "fontSize": "xxlarge"
+                }
+            },
             "attributes": {
                 "isStatus": false,
                 "sortable": false,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -177,6 +177,24 @@
         {
             "name": "id",
             "component": "BoldText",
+            "appearance": {
+                "desktop": {
+                    "fontSize": "base",
+                    "align": "left",
+                    "verticalAlign": "center"
+                },
+                "mobile": {
+                    "fontSize": "baseSmall",
+                    "align": "center",
+                    "verticalAlign": "top"
+                },
+                "default": {
+                    "fontColor": "blue",
+                    "fontSize": "small",
+                    "align": "right",
+                    "verticalAlign": "bottom"
+                }
+            },
             "attributes": {
                 "sortable": true,
                 "isDefaultSort": true,
@@ -192,6 +210,17 @@
         {
             "name": "motiveName",
             "component": "MediumText",
+            "appearance": {
+                "desktop": {
+                    "fontSize": "xsmall"
+                },
+                "mobile": {
+                    "fontSize": "large"
+                },
+                "default": {
+                    "fontSize": "xlarge"
+                }
+            },
             "filter": {
                 "component": "Input",
                 "type": "equal",
@@ -212,6 +241,11 @@
         {
             "name": "parentName",
             "component": "Text",
+            "appearance": {
+                "default": {
+                    "fontSize": "xxlarge"
+                }
+            },
             "attributes": {
                 "isStatus": false,
                 "sortable": false,


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1212

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se debe agregar la prop de `appearance`  como lo tiene el browse, pero con las siguientes propiedades:

- Alineación horizontal (**align** - _left_|_center_|_right_)
- Alineación vertical (**verticalAlign** - _top_|_center_|_bottom_)
- Color de fuente (**fontColor** - string) - El color se debe procesar como siempre.
- Tamaño de fuente (**fontSize** - _base_|_baseSmall_|_small_|_xsmall_|_large_|_xlarge_|_xxlarge_)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó la prop de appearance como lo tiene el browse pero con las propiedades descriptas arriba.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README