### PR TITLE
add endpointParamenters for ListTooltip and ListNodal components

### DIFF
--- a/lib/schemas/browse/modules/interactions.js
+++ b/lib/schemas/browse/modules/interactions.js
@@ -31,6 +31,7 @@ const interactionComponents = [
 			properties: {
 				type: { enum: ['ListTooltip', 'ListModal'] },
 				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+				endpointParameters: getStaticFilters(),
 				translateLabels: { type: 'boolean' },
 				title: { type: 'string' },
 				listFields: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -700,6 +700,15 @@
                         "method": "methodName",
                         "resolve": false
                     },
+                    "endpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ],
                     "listFields": ["fieldName"]
                 },
                 "desktop": {

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -997,6 +997,15 @@
                         "method": "methodName",
                         "resolve": false
                     },
+                    "endpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ],
                     "listFields": ["fieldName"]
                 },
                 "desktop": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -997,6 +997,15 @@
                         "method": "methodName",
                         "resolve": false
                     },
+                    "endpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "static": "fieldId"
+                            }
+                        }
+                    ],
                     "listFields": ["fieldName"]
                 },
                 "desktop": {


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1263

DESCRIPCIÓN DEL REQUERIMIENTO

Agregar endpointParameters al schema de ListTooltips y ListModal

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó la prop de endpointParameters en el shema de interactions de field de browse

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README