### PR TITLE
Jmv 1284 and 1294 suffix preffix currency mappers new props

### DIFF
--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -2,119 +2,132 @@
 
 const MAPPERS = ['addHashtag', 'booleanToStatus', 'booleanToWord', 'translate'];
 
-const Mapper = {
+const baseMapperSchema = [
+	{
+		if: { type: 'string' },
+		then: { type: 'string' }
+	},
+	{
+		if: {
+			type: 'object',
+			properties: {
+				name: { const: 'numberToTime' }
+			}
+		},
+		then: {
+			properties: {
+				name: { const: 'numberToTime' },
+				props: {
+					type: 'object',
+					properties: {
+						type: {
+							type: 'string',
+							enum: ['minute', 'hour', 'day', 'week'],
+							default: 'hour'
+						}
+					},
+					additionalProperties: false
+				}
+			}
+		}
+	},
+	{
+		if: {
+			type: 'object',
+			properties: {
+				name: { const: 'date' }
+			}
+		},
+		then: {
+			properties: {
+				name: { const: 'date' },
+				props: {
+					type: 'object',
+					properties: {
+						format: {
+							type: 'string'
+						}
+					},
+					additionalProperties: false
+				}
+			}
+		}
+	},
+	{
+		if: {
+			type: 'object',
+			properties: {
+				name: { const: 'prefix' }
+			}
+		},
+		then: {
+			properties: {
+				name: { const: 'prefix' },
+				props: {
+					type: 'object',
+					properties: {
+						translate: { type: 'boolean' },
+						value: { type: 'string' }
+					},
+					additionalProperties: false
+				}
+			}
+		}
+	},
+	{
+		if: {
+			type: 'object',
+			properties: {
+				name: { const: 'suffix' }
+			}
+		},
+		then: {
+			properties: {
+				name: { const: 'suffix' },
+				props: {
+					type: 'object',
+					properties: {
+						translate: { type: 'boolean' },
+						value: { type: 'string' }
+					},
+					additionalProperties: false
+				}
+			}
+		}
+	},
+	{
+		if: {
+			type: 'object',
+			properties: {
+				name: { enum: MAPPERS }
+			}
+		},
+		then: {
+			type: 'object',
+			properties: {
+				name: { enum: MAPPERS }
+			},
+			additionalProperties: false
+		}
+	}
+];
+
+const mapperSchema = {
 	allOf: [
-		{
-			if: { type: 'string' },
-			then: { type: 'string' }
-		},
+		...baseMapperSchema,
 		{
 			if: {
-				type: 'object',
-				properties: {
-					name: { const: 'numberToTime' }
-				}
+				type: 'array'
 			},
 			then: {
-				properties: {
-					name: { const: 'numberToTime' },
-					props: {
-						type: 'object',
-						properties: {
-							type: {
-								type: 'string',
-								enum: ['minute', 'hour', 'day', 'week'],
-								default: 'hour'
-							}
-						},
-						additionalProperties: false
-					}
+				type: 'array',
+				items: {
+					allOf: baseMapperSchema
 				}
-			}
-		},
-		{
-			if: {
-				type: 'object',
-				properties: {
-					name: { const: 'date' }
-				}
-			},
-			then: {
-				properties: {
-					name: { const: 'date' },
-					props: {
-						type: 'object',
-						properties: {
-							format: {
-								type: 'string'
-							}
-						},
-						additionalProperties: false
-					}
-				}
-			}
-		},
-		{
-			if: {
-				type: 'object',
-				properties: {
-					name: { const: 'prefix' }
-				}
-			},
-			then: {
-				properties: {
-					name: { const: 'prefix' },
-					props: {
-						type: 'object',
-						properties: {
-							value: {
-								type: 'string'
-							}
-						},
-						additionalProperties: false
-					}
-				}
-			}
-		},
-		{
-			if: {
-				type: 'object',
-				properties: {
-					name: { const: 'suffix' }
-				}
-			},
-			then: {
-				properties: {
-					name: { const: 'suffix' },
-					props: {
-						type: 'object',
-						properties: {
-							value: {
-								type: 'string'
-							}
-						},
-						additionalProperties: false
-					}
-				}
-			}
-		},
-		{
-			if: {
-				type: 'object',
-				properties: {
-					name: { enum: MAPPERS }
-				}
-			},
-			then: {
-				type: 'object',
-				properties: {
-					name: { enum: MAPPERS }
-				},
-				additionalProperties: false
 			}
 		}
 	]
 };
 
 
-module.exports = Mapper;
+module.exports = mapperSchema;

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -783,13 +783,15 @@
                         {
                             "name": "suffix",
                             "props":{
-                                "value": "comon.test."
+                                "value": "comon.test.",
+                                "translate": true
                             }
                         },
                         {
                             "name": "prefix",
                             "props":{
-                                "value": "comon.test."
+                                "value": "comon.test.",
+                                "translate": false
                             }
                         }
                     ]

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -183,7 +183,16 @@ sections:
       mapper:
         name: suffix
         props:
-         value: .test
+          value: .test
+          translate: true
+
+    - name: exampleTextPrefix
+      component: Text
+      mapper:
+        name: prefix
+        props:
+          value: .test
+          translate: false
 
     - name: exampleStatuChipOne
       component: StatusChip

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -1089,13 +1089,15 @@
                         {
                             "name": "suffix",
                             "props":{
-                                "value": "comon.test."
+                                "value": "comon.test.",
+                                "translate": true
                             }
                         },
                         {
                             "name": "prefix",
                             "props":{
-                                "value": "comon.test."
+                                "value": "comon.test.",
+                                "translate": false
                             }
                         }
                     ]

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -1089,13 +1089,15 @@
                         {
                             "name": "suffix",
                             "props":{
-                                "value": "comon.test."
+                                "value": "comon.test.",
+                                "translate": true
                             }
                         },
                         {
                             "name": "prefix",
                             "props":{
-                                "value": "comon.test."
+                                "value": "comon.test.",
+                                "translate": false
                             }
                         }
                     ]

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -303,7 +303,20 @@
                             "mapper": {
                                 "name": "suffix",
                                 "props": {
-                                    "value": ".test"
+                                    "value": ".test",
+                                    "translate": true
+                                }
+                            },
+                            "componentAttributes": {}
+                        },
+                        {
+                            "name": "exampleTextPrefix",
+                            "component": "Text",
+                            "mapper": {
+                                "name": "prefix",
+                                "props": {
+                                    "value": ".test",
+                                    "translate": false
                                 }
                             },
                             "componentAttributes": {}


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1284
https://fizzmod.atlassian.net/browse/JMV-1294

**DESCRIPCIÓN DEL REQUERIMIENTO**

Agregar prop a mappers de suffix y prefix
- translate: BOOLEAN|OPTIONAL

Agregar mapper de currency con las siguientes props
- currencyCode: STRING|OPTIONAL
-  currencyField: STRING|OPTIONAL


**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las props a los mappers descriptions arriba. Se hizo un refactor de los mappers para que validen los mapper que son un array de los mismos.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README