### PR TITLE
JMV-1292 add edit custom validations

### DIFF
--- a/lib/custom-schema-validator.js
+++ b/lib/custom-schema-validator.js
@@ -1,0 +1,37 @@
+'use strict';
+
+class CustomSchemaValidator {
+
+	/**
+	 * Validate if schema edit must have source prop defined
+	 * @name validateMainFormSource
+	 * @param {object} schema
+	 * @return {object}
+	 */
+	static validateMainFormSource(schema) {
+		const hasMainForm = schema.sections.some(({ rootComponent }) => rootComponent === 'MainForm');
+
+		if(hasMainForm && !schema.source)
+			throw new Error('Edit Schema requires ´source´ property because MainForm Section exists');
+
+		return schema;
+	}
+
+	/**
+	 * Check if is a edit schema
+	 * @param {object} schema
+	 * @return {boolean}
+	 */
+	static isEdit(schema) {
+		return schema.root === 'Edit';
+	}
+
+	static execute(schema) {
+		if(this.isEdit(schema))
+			return this.validateMainFormSource(schema);
+
+		return schema;
+	}
+}
+
+module.exports = CustomSchemaValidator;

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -12,5 +12,5 @@ module.exports = {
 			$ref: 'schemaDefinitions#/definitions/endpoint'
 		}
 	},
-	required: [...required, 'source']
+	required: [...required]
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -5,6 +5,7 @@ const logger = require('lllog')();
 const schemas = require('./schemas');
 const schemaDefinitions = require('./schemas/definitions');
 const schemaModifier = require('./schema-modifier');
+const customSchemaValidator = require('./custom-schema-validator');
 
 const ajv = new Ajv({ allErrors: true, useDefaults: true, schemas: [schemaDefinitions] });
 
@@ -53,6 +54,8 @@ class Validator {
 			error.errors = ajv.errors;
 			throw error;
 		}
+
+		customSchemaValidator.execute(schema, filePath);
 
 		logger.info(`VALIDATION SUCCESS  --> ${filePath}`);
 

--- a/tests/custom-schema-validator.js
+++ b/tests/custom-schema-validator.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const fs = require('fs-extra');
+const schemaModifier = require('../lib/custom-schema-validator');
+
+const schemaCompiled = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit.json');
+const schemaCompiledTwo = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/browse.json');
+
+const sandbox = sinon.createSandbox();
+
+describe('custom-schema-validator', () => {
+	beforeEach(() => {
+		sandbox.restore();
+	});
+
+	it('should pass validation if exist source prop and MainForm Section', async () => {
+		const validateMainFormSourceSpy = sandbox.spy(schemaModifier, 'validateMainFormSource');
+
+		const schemaOne = JSON.parse(schemaCompiled.toString());
+
+		const dataOne = schemaModifier.execute(schemaOne);
+
+		assert(validateMainFormSourceSpy.calledOnce);
+
+		assert.deepEqual(dataOne, schemaOne);
+	});
+
+	it('should pass validation if not is a Edit Schema', async () => {
+		const validateMainFormSourceSpy = sandbox.spy(schemaModifier, 'validateMainFormSource');
+
+		const schemaOne = JSON.parse(schemaCompiledTwo.toString());
+
+		const dataOne = schemaModifier.execute(schemaOne);
+
+		assert(validateMainFormSourceSpy.notCalled);
+
+		assert.deepEqual(dataOne, schemaOne);
+	});
+
+	it('should return an error if not exist source prop and exist MainForm section', async () => {
+		const validateMainFormSourceSpy = sandbox.spy(schemaModifier, 'validateMainFormSource');
+
+		const schemaOne = JSON.parse(schemaCompiled.toString());
+
+		delete schemaOne.source;
+
+		const message = 'Edit Schema requires ´source´ property because MainForm Section exists';
+
+		assert.throws(() => schemaModifier.execute(schemaOne), { message });
+		assert(validateMainFormSourceSpy.calledOnce);
+	});
+
+	it('should pass validation if not exist source prop and not exist MainForm section', async () => {
+		const validateMainFormSourceSpy = sandbox.spy(schemaModifier, 'validateMainFormSource');
+
+		const schemaOne = JSON.parse(schemaCompiled.toString());
+
+		delete schemaOne.source;
+
+		schemaOne.sections = schemaOne.sections.filter(section => section.rootComponent !== 'MainForm');
+
+		const dataOne = schemaModifier.execute(schemaOne);
+
+		assert(validateMainFormSourceSpy.calledOnce);
+		assert.deepEqual(dataOne, schemaOne);
+	});
+
+});


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1292

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe empezar a validar el campo source de los Edits como opcional sólo cuando no haya un MainForm en el schema.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se saco de la prop source de requeridos, y se hizo una clase que se ejecuta luego de la validacion de schema para verificar si se debe requerir o no esta prop.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README