### PR TITLE
add async wrapper brows new props

### DIFF
--- a/lib/schemas/browse/modules/components/asyncWrapper.js
+++ b/lib/schemas/browse/modules/components/asyncWrapper.js
@@ -11,9 +11,17 @@ module.exports = makeComponent({
 			type: 'object',
 			additionalProperties: { type: 'string' }
 		},
-		field: {
-			$ref: 'schemaDefinitions#/definitions/browseField'
-		}
+		dataMatching: {
+			type: 'object',
+			properties: {
+				local: { type: 'string' },
+				remote: { type: 'string' }
+			},
+			minProperties: 2,
+			additionalProperties: false
+		},
+		field: { $ref: 'schemaDefinitions#/definitions/browseField' },
+		targetField: { type: 'string' }
 	},
 	requiredProperties: ['dataMapping', 'source', 'field']
 });

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -564,6 +564,30 @@
             }
         },
         {
+            "name": "asyncWrapperNewExample",
+            "component": "AsyncWrapper",
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "userTest"
+                },
+                "dataMatching": {
+                    "local": "id",
+                    "remote": "someId"
+                },
+                "targetField": "fieldName",
+                "field": {
+                    "name": "userTest",
+                    "component": "Text"
+                }
+            }
+        },
+        {
             "name": "multiValueWrapperExampleOne",
             "component": "MultiValueWrapper",
             "componentAttributes": {

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -775,6 +775,45 @@
             }
         },
         {
+            "name": "asyncWrapperNewExample",
+            "component": "AsyncWrapper",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "userTest"
+                },
+                "dataMatching": {
+                    "local": "id",
+                    "remote": "someId"
+                },
+                "targetField": "fieldName",
+                "field": {
+                    "name": "userTest",
+                    "component": "Text",
+                    "attributes": {
+                        "isStatus": false,
+                        "sortable": false,
+                        "isDefaultSort": false,
+                        "initialSortDirection": "desc"
+                    },
+                    "componentAttributes": {
+                        "fontWeight": "normal"
+                    }
+                }
+            }
+        },
+        {
             "name": "multiValueWrapperExampleOne",
             "component": "MultiValueWrapper",
             "attributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -775,6 +775,45 @@
             }
         },
         {
+            "name": "asyncWrapperNewExample",
+            "component": "AsyncWrapper",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
+                "source": {
+                    "service": "id",
+                    "namespace": "user",
+                    "method": "list",
+                    "resolve": false
+                },
+                "dataMapping": {
+                    "firstname": "userTest"
+                },
+                "dataMatching": {
+                    "local": "id",
+                    "remote": "someId"
+                },
+                "targetField": "fieldName",
+                "field": {
+                    "name": "userTest",
+                    "component": "Text",
+                    "attributes": {
+                        "isStatus": false,
+                        "sortable": false,
+                        "isDefaultSort": false,
+                        "initialSortDirection": "desc"
+                    },
+                    "componentAttributes": {
+                        "fontWeight": "normal"
+                    }
+                }
+            }
+        },
+        {
             "name": "multiValueWrapperExampleOne",
             "component": "MultiValueWrapper",
             "attributes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1296

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deben agregar las siguientes nuevas props al schema de AsyncWrapper de browse

```
dataMatching: (object|optional|min2props)
  local: (STRING|require)
  remote: (STRING|require)
targetField: (STRING|OPTIONAL)
```

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las props al schema del AsyncWrapper del browse

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README