### PR TITLE
add new prop for include data from others sections

### DIFF
--- a/lib/schemas/edit-new/modules/sections/commonProperties.js
+++ b/lib/schemas/edit-new/modules/sections/commonProperties.js
@@ -5,6 +5,11 @@ const makeConditions = require('../../../common/conditions');
 
 module.exports = {
 	topComponents,
+	includeDataFrom: {
+		type: 'array',
+		items: { type: 'string' },
+		minItems: 1
+	},
 	collapse: { type: 'boolean' },
 	icon: { type: 'string' },
 	conditions: makeConditions(false)

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -818,6 +818,7 @@ sections:
       target: path
       value:
         static: serviceName
+
   targetEndpointParameters:
     - name: status
       target: path
@@ -827,6 +828,9 @@ sections:
       target: query
       value:
         static: 1
+
+  includeDataFrom:
+    - someSection
 
   fieldsGroup:
   - name: detail

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1357,6 +1357,9 @@
                     }
                 }
             ],
+            "includeDataFrom": [
+                "someSection"
+            ],
             "fieldsGroup": [
                 {
                     "name": "detail",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1341

DESCRIPCIÓN DEL REQUERIMIENTO

Se debe agregar una nueva prop a las secciones de edit para indicar de que secciones de form incluir data, para validaciones y componentes de topComponents

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego la prop includeDataFrom en seccines como array de string que indique las secciones de form a incluir en la data utlizada por los TopComponents

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README