### PR TITLE
Jmv 1334 schema dashboard and new props for browse

### DIFF
--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -4,6 +4,7 @@ const filters = require('../browse/modules/filters');
 const themes = require('./status-themes');
 const sortableFields = require('../browse/modules/sortableFields');
 const getStaticFilters = require('./staticFilters');
+const graphs = require('./graphs');
 
 const PAGE_SIZES = [15, 30, 60, 100];
 const DEFAULT_PAGE_SIZE = 60;
@@ -51,6 +52,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		canExport: { type: 'boolean', default: false },
 		canRefresh: { type: 'boolean' },
 		appearance: makeAppearance(),
+		graphs,
 		themes,
 		filters,
 		sortableFields,

--- a/lib/schemas/common/graphs.js
+++ b/lib/schemas/common/graphs.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const filters = require('../browse/modules/filters');
+const getStaticFilters = require('./staticFilters');
+
+module.exports = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			filters,
+			component: { type: 'string' },
+			name: { type: 'string' },
+			title: { type: 'string' },
+			translateTitle: { type: 'boolean' },
+			subtitle: { type: 'string' },
+			translateSubtitle: { type: 'boolean' },
+			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			endpointParameters: getStaticFilters(),
+			componentAttributes: { type: 'object' },
+			x: { type: 'number' },
+			y: { type: 'number' },
+			width: { type: 'number' },
+			height: { type: 'number' }
+		},
+		additionalProperties: false,
+		required: ['component', 'name', 'title', 'x', 'y', 'width', 'height']
+	},
+	minItems: 1
+};

--- a/lib/schemas/common/graphs.js
+++ b/lib/schemas/common/graphs.js
@@ -24,7 +24,7 @@ module.exports = {
 			height: { type: 'number' }
 		},
 		additionalProperties: false,
-		required: ['component', 'name', 'title', 'x', 'y', 'width', 'height']
+		required: ['component', 'name', 'x', 'y', 'width', 'height']
 	},
 	minItems: 1
 };

--- a/lib/schemas/common/graphs.js
+++ b/lib/schemas/common/graphs.js
@@ -24,7 +24,7 @@ module.exports = {
 			height: { type: 'number' }
 		},
 		additionalProperties: false,
-		required: ['component', 'name', 'x', 'y', 'width', 'height']
+		required: ['component', 'source', 'name', 'x', 'y', 'width', 'height']
 	},
 	minItems: 1
 };

--- a/lib/schemas/dashboard/schema.js
+++ b/lib/schemas/dashboard/schema.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { properties, required } = require('../common/base');
+const filters = require('../browse/modules/filters');
+const graphs = require('../common/graphs');
+
+module.exports = {
+	type: 'object',
+	properties: {
+		...properties,
+		root: { const: 'Dashboard' },
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		filters,
+		graphs
+	},
+	additionalProperties: false,
+	required: [...required, 'graphs']
+};

--- a/lib/schemas/dashboard/schema.js
+++ b/lib/schemas/dashboard/schema.js
@@ -9,7 +9,6 @@ module.exports = {
 	properties: {
 		...properties,
 		root: { const: 'Dashboard' },
-		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		filters,
 		graphs
 	},

--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -3,11 +3,13 @@
 const browse = require('./browse/schema');
 const edit = require('./edit/schema');
 const create = require('./new/schema');
+const dashboard = require('./dashboard/schema');
 const defaultSchema = require('./default/schema');
 
 module.exports = {
 	browse,
 	edit,
 	create,
+	dashboard,
 	defaultSchema
 };

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -65,6 +65,39 @@
             "initialSortDirection": "asc"
         }
     ],
+    "graphs": [
+        {
+            "component": "Table",
+            "name": "graphName",
+            "title": "someTitleForGraph",
+            "source": {
+                "service": "serviceName",
+                "namespace": "namespaceName",
+                "method": "methodName",
+                "resolve": false
+            },
+            "endpointParameters": [
+                {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                        "dynamic": "id"
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": 1
+                    }
+                }
+            ],
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 3
+        }
+    ],
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/dashboard.yml
+++ b/tests/mocks/schemas/dashboard.yml
@@ -1,18 +1,12 @@
 service: serviceName
 name: example-dashboard
 root: Dashboard
-source:
-  service: serviceName
-  namespace: namespaceName
-  method: methodName
-  resolve: false
 filters:
   - name: filterInput
     label: someLabel
     component: Input
     componentAttributes:
       icon: iconName
-
 graphs:
   - component: Table
     name: graphName

--- a/tests/mocks/schemas/dashboard.yml
+++ b/tests/mocks/schemas/dashboard.yml
@@ -1,0 +1,53 @@
+service: serviceName
+name: example-dashboard
+root: Dashboard
+source:
+  service: serviceName
+  namespace: namespaceName
+  method: methodName
+  resolve: false
+filters:
+  - name: filterInput
+    label: someLabel
+    component: Input
+    componentAttributes:
+      icon: iconName
+
+graphs:
+  - component: Table
+    name: graphName
+    title: someTitleForGraph
+    source:
+      service: serviceName
+      namespace: namespaceName
+      method: methodName
+      resolve: false
+    endpointParameters:
+      - name: status
+        target: path
+        value:
+          dynamic: id
+      - name: status
+        target: query
+        value:
+          static: 1
+    x: 0
+    y: 0
+    width: 6
+    height: 3
+
+  - component: BarChart
+    name: graphName
+    title: someTitleForGraph
+    translateTitle: true
+    subtitle: someSubtitleForGraph
+    translateSubtitle: true
+    componentAttributes:
+      options:
+        width: 100%
+    x: 6
+    y: 0
+    width: 6
+    height: 3
+
+

--- a/tests/mocks/schemas/dashboard.yml
+++ b/tests/mocks/schemas/dashboard.yml
@@ -36,6 +36,11 @@ graphs:
     translateTitle: true
     subtitle: someSubtitleForGraph
     translateSubtitle: true
+    source:
+      service: serviceName
+      namespace: namespaceName
+      method: methodName
+      resolve: false
     componentAttributes:
       options:
         width: 100%

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -64,6 +64,40 @@
             "initialSortDirection": "asc"
         }
     ],
+    "graphs": [
+        {
+            "component": "Table",
+            "filters": [],
+            "name": "graphName",
+            "title": "someTitleForGraph",
+            "source": {
+                "service": "serviceName",
+                "namespace": "namespaceName",
+                "method": "methodName",
+                "resolve": false
+            },
+            "endpointParameters": [
+                {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                        "dynamic": "id"
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": 1
+                    }
+                }
+            ],
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 3
+        }
+    ],
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -64,6 +64,40 @@
             "initialSortDirection": "asc"
         }
     ],
+    "graphs": [
+        {
+            "component": "Table",
+            "filters": [],
+            "name": "graphName",
+            "title": "someTitleForGraph",
+            "source": {
+                "service": "serviceName",
+                "namespace": "namespaceName",
+                "method": "methodName",
+                "resolve": false
+            },
+            "endpointParameters": [
+                {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                        "dynamic": "id"
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": 1
+                    }
+                }
+            ],
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 3
+        }
+    ],
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/dashboard.json
+++ b/tests/mocks/schemas/expected/dashboard.json
@@ -1,0 +1,73 @@
+{
+    "service": "serviceName",
+    "name": "example-dashboard",
+    "root": "Dashboard",
+    "source": {
+        "service": "serviceName",
+        "namespace": "namespaceName",
+        "method": "methodName",
+        "resolve": false
+    },
+    "filters": [
+        {
+            "name": "filterInput",
+            "label": "someLabel",
+            "component": "Input",
+            "componentAttributes": {
+                "icon": "iconName"
+            }
+        }
+    ],
+    "graphs": [
+        {
+            "component": "Table",
+            "filters": [],
+            "name": "graphName",
+            "title": "someTitleForGraph",
+            "source": {
+                "service": "serviceName",
+                "namespace": "namespaceName",
+                "method": "methodName",
+                "resolve": false
+            },
+            "endpointParameters": [
+                {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                        "dynamic": "id"
+                    }
+                },
+                {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                        "static": 1
+                    }
+                }
+            ],
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 3
+        },
+        {
+            "component": "BarChart",
+            "filters": [],
+            "name": "graphName",
+            "title": "someTitleForGraph",
+            "translateTitle": true,
+            "subtitle": "someSubtitleForGraph",
+            "translateSubtitle": true,
+            "componentAttributes": {
+                "options": {
+                    "width": "100%"
+                }
+            },
+            "x": 6,
+            "y": 0,
+            "width": 6,
+            "height": 3
+        }
+    ]
+}

--- a/tests/mocks/schemas/expected/dashboard.json
+++ b/tests/mocks/schemas/expected/dashboard.json
@@ -2,12 +2,6 @@
     "service": "serviceName",
     "name": "example-dashboard",
     "root": "Dashboard",
-    "source": {
-        "service": "serviceName",
-        "namespace": "namespaceName",
-        "method": "methodName",
-        "resolve": false
-    },
     "filters": [
         {
             "name": "filterInput",

--- a/tests/mocks/schemas/expected/dashboard.json
+++ b/tests/mocks/schemas/expected/dashboard.json
@@ -52,6 +52,12 @@
             "title": "someTitleForGraph",
             "translateTitle": true,
             "subtitle": "someSubtitleForGraph",
+            "source": {
+                "service": "serviceName",
+                "namespace": "namespaceName",
+                "method": "methodName",
+                "resolve": false
+            },
             "translateSubtitle": true,
             "componentAttributes": {
                 "options": {

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -11,6 +11,8 @@ const schemaExampleOne = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/b
 const schemaExpectedExampleOne = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/browse.json');
 const schemaExampleYmlTwo = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit.yml');
 const schemaExpectedExampleTwo = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit.json');
+const schemaExampleYmlThree = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/dashboard.yml');
+const schemaExpectedExampleThree = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/dashboard.json');
 
 const sandbox = sinon.createSandbox();
 
@@ -76,12 +78,15 @@ describe('Test validation functions', () => {
 	it('should schema builded is a expected', () => {
 		const schemaOne = JSON.parse(schemaExampleOne.toString());
 		const schemaTwo = ymljs.parse(schemaExampleYmlTwo.toString());
+		const schemaThree = ymljs.parse(schemaExampleYmlThree.toString());
 
 		const dataOne = Validator.execute(schemaOne, true, '/test/data1.json');
 		const dataTwo = Validator.execute(schemaTwo, true, '/test/data2.json');
+		const dataThree = Validator.execute(schemaThree, true, '/test/data3.json');
 
 		sandbox.assert.match(dataOne, JSON.parse(schemaExpectedExampleOne.toString()));
 		sandbox.assert.match(dataTwo, JSON.parse(schemaExpectedExampleTwo.toString()));
+		sandbox.assert.match(dataThree, JSON.parse(schemaExpectedExampleThree.toString()));
 	});
 
 	it('should error with default schema', () => {


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1334

DESCRIPCIÓN DEL REQUERIMIENTO

Se deberá crear un tipo de schema nuevo
Deberá reutilizar la prop de filters de los browses
Deberá contener una prop graphs (validar nombre) como requerido, y debe contener al menos 1 gráfico

Los gráficos deberán tener como requeridas las siguientes properties:

component: tipo de gráfico (columnChart, Table)(required)
filters: Deberá reutilizar la prop de filters de los browses(optional)
name: identificador string(required)
title: titulo de char(optional)
subtitile: subtitulo de charts(optional)
source: SourceEndpoint (required)
endpointParameters: statisFilters-endpointparamters (optional)
componentAttributes: objeto con opciones de graficos (optional)
x: donde empieza en el eje X - (required)
y: donde empieza en el eje Y -(required)
width: tamaño para el eje X - (required)
heigth: tamaño para el eje Y- (required)

DESCRIPCIÓN DE LA SOLUCIÓN

Se agrego  un nuevo schema de pagina para el dashboard y se agrego al browse  una nueva prop para agregar greficos.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README