### PR TITLE
JMV-1381 add remoteActions properties

### DIFF
--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -2,14 +2,24 @@
 
 const { properties, required, newEditSchema } = require('../edit-new/schema');
 const themes = require('../common/status-themes');
+const getStaticFilters = require('../common/staticFilters');
 
 module.exports = {
 	...newEditSchema,
 	properties: {
 		...properties,
 		themes,
-		source: {
-			$ref: 'schemaDefinitions#/definitions/endpoint'
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		remoteActions: {
+			type: 'object',
+			properties: {
+				title: { type: 'string' },
+				translateTitle: { type: 'boolean' },
+				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+				sourceEndpointParameters: getStaticFilters()
+			},
+			required: ['source'],
+			additionalProperties: false
 		}
 	},
 	required: [...required]

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -43,7 +43,27 @@ themes:
   themeTwo:
     new: grey
     closed: fizzgreen
+
 collapseSections: true
+
+remoteActions:
+  title: some.title
+  translateTitle: true
+  source:
+    service: serviceName
+    namespace: namespaceName
+    method: methodName
+    resolve: false
+  sourceEndpointParameters:
+    - name: status
+      target: path
+      value:
+        dynamic: id
+    - name: status
+      target: query
+      value:
+        static: 1
+
 sections:
 - name: mainFormSection
   rootComponent: MainForm

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -64,6 +64,32 @@
         }
     },
     "collapseSections": true,
+    "remoteActions": {
+        "title": "some.title",
+        "translateTitle": true,
+        "source": {
+            "service": "serviceName",
+            "namespace": "namespaceName",
+            "method": "methodName",
+            "resolve": false
+        },
+        "sourceEndpointParameters": [
+            {
+                "name": "status",
+                "target": "path",
+                "value": {
+                    "dynamic": "id"
+                }
+            },
+            {
+                "name": "status",
+                "target": "query",
+                "value": {
+                    "static": 1
+                }
+            }
+        ]
+    },
     "sections": [
         {
             "name": "mainFormSection",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1381

DESCRIPCIÓN DEL REQUERIMIENTO

Agregar  prop "remoteActions" al schema de edit/create
Opcionalmente se podrá pasar un titulo para el popup
Deberá ser un objeto con un source y sourceEndpointParameters

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregue la props remoteActions que es un objeto opcional con source , sourceEndpointParameters, titile y translateTitle

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README