### PR TITLE
JMV-1373 add dateTimepicker new props

### DIFF
--- a/lib/schemas/browse/modules/filters/components/dateTimePicker.js
+++ b/lib/schemas/browse/modules/filters/components/dateTimePicker.js
@@ -6,6 +6,8 @@ const { dateTimePicker } = require('../componentNames');
 module.exports = makeComponent({
 	name: dateTimePicker,
 	properties: {
+		setStartOfDay: { type: 'boolean' },
+		setEndOfDay: { type: 'boolean' },
 		selectRange: { type: 'boolean' },
 		selectDate: { type: 'boolean' },
 		selectTime: { type: 'boolean' }

--- a/lib/schemas/edit-new/modules/components/dateTimePicker.js
+++ b/lib/schemas/edit-new/modules/components/dateTimePicker.js
@@ -6,6 +6,8 @@ const { dateTimePicker } = require('../componentNames');
 module.exports = makeComponent({
 	name: dateTimePicker,
 	properties: {
+		setStartOfDay: { type: 'boolean' },
+		setEndOfDay: { type: 'boolean' },
 		selectRange: { type: 'boolean' },
 		selectDate: { type: 'boolean' },
 		selectTime: { type: 'boolean' }

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -205,6 +205,16 @@
             }
         },
         {
+            "name": "otherDateTime",
+            "component": "DateTimePicker",
+            "componentAttributes": {
+                "selectDate": true,
+                "selectRange": true,
+                "setStartOfDay": true,
+                "setEndOfDay": true
+            }
+        },
+        {
             "name": "userAssigned",
             "component": "UserSelector"
         },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -517,6 +517,15 @@ sections:
           selectDate: false
           selectTime: true
           selectRange: true
+
+      - name: otherDateTime
+        component: DateTimePicker
+        componentAttributes:
+          selectDate: true
+          selectRange: true
+          setStartOfDay: true
+          setEndOfDay: true
+
       - name: checklist
         component: CheckList
         componentAttributes:

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -207,6 +207,16 @@
             }
         },
         {
+            "name": "otherDateTime",
+            "component": "DateTimePicker",
+            "componentAttributes": {
+                "selectDate": true,
+                "selectRange": true,
+                "setStartOfDay": true,
+                "setEndOfDay": true
+            }
+        },
+        {
             "name": "userAssigned",
             "component": "UserSelector",
             "componentAttributes": {}

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -207,6 +207,16 @@
             }
         },
         {
+            "name": "otherDateTime",
+            "component": "DateTimePicker",
+            "componentAttributes": {
+                "selectDate": true,
+                "selectRange": true,
+                "setStartOfDay": true,
+                "setEndOfDay": true
+            }
+        },
+        {
             "name": "userAssigned",
             "component": "UserSelector",
             "componentAttributes": {}

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -818,6 +818,16 @@
                             }
                         },
                         {
+                            "name": "otherDateTime",
+                            "component": "DateTimePicker",
+                            "componentAttributes": {
+                                "selectDate": true,
+                                "selectRange": true,
+                                "setStartOfDay": true,
+                                "setEndOfDay": true
+                            }
+                        },
+                        {
                             "name": "checklist",
                             "component": "CheckList",
                             "componentAttributes": {


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1373

DESCRIPCIÓN DEL REQUERIMIENTO

Se deberá agregar dos props nuevas, en el componente de DateTimePicker 
La prop setStartOfDay (boolean|opcional) 
la prop setEndOfDay(boolean|opcional)


DESCRIPCIÓN DE LA SOLUCIÓN

Se agregaron las nuevas props a los componentes de DateTimePicker existentes

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README