### PR TITLE
add default value prop in field form

### DIFF
--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -16,6 +16,15 @@ module.exports = {
 		label: { type: 'string' },
 		noLabel: { type: 'boolean' },
 		attributes,
+		defaultValue: {
+			anyOf: [
+				{ type: 'string' },
+				{ type: 'boolean' },
+				{ type: 'number' },
+				{ type: 'object' },
+				{ type: 'array' }
+			]
+		},
 		componentAttributes: {
 			type: 'object',
 			default: {}

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -242,6 +242,7 @@ sections:
 
     - name: appliesToLogistics
       component: Switch
+      defaultValue: true
       validations:
         - - name: required
 
@@ -260,6 +261,7 @@ sections:
 
     - name: testChip
       component: Chip
+      defaultValue: someValue
       componentAttributes:
         icon: icon_test
         iconColor: red
@@ -432,6 +434,7 @@ sections:
     fields:
       - name: status
         component: Select
+        defaultValue: active
         validations:
           - - name: required
         componentAttributes:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -386,6 +386,7 @@
                         {
                             "name": "appliesToLogistics",
                             "component": "Switch",
+                            "defaultValue": true,
                             "validations": [
                                 [
                                     {
@@ -426,6 +427,7 @@
                         {
                             "name": "testChip",
                             "component": "Chip",
+                            "defaultValue": "someValue",
                             "componentAttributes": {
                                 "icon": "icon_test",
                                 "iconColor": "red",
@@ -683,6 +685,7 @@
                         {
                             "name": "status",
                             "component": "Select",
+                            "defaultValue": "active",
                             "validations": [
                                 [
                                     {


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1463

DESCRIPCIÓN DEL REQUERIMIENTO

Se deberá agregar una nueva prop opcional llamada defaultValue
Se deberá poder usar en todos los componentes: 

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó una nueva prop a los Fields de Forms, de todos los tipos de datos

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README