### PR TITLE
add order items new props

### DIFF
--- a/lib/schemas/edit-new/modules/sections/orderItemsSection.js
+++ b/lib/schemas/edit-new/modules/sections/orderItemsSection.js
@@ -16,7 +16,12 @@ module.exports = {
 			rootComponent: { type: 'string', const: orderItemsSection },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 			sourceField: { type: 'string' },
-			staticFilters: getStaticFilters()
+			staticFilters: getStaticFilters(),
+			showPickingSessions: { type: 'boolean' },
+			showPurchasedItems: { type: 'boolean' },
+			showPickedItems: { type: 'boolean' },
+			showClaimItems: { type: 'boolean' },
+			canEditPrice: { type: 'boolean' }
 		},
 		required: ['name', 'rootComponent'],
 		additionalProperties: false

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -822,7 +822,12 @@ sections:
       target: query
       value:
         static:
-          id: "string"
+          id: string
+  showPickingSessions: true
+  showPurchasedItems: false
+  showPickedItems: true
+  showClaimItems: false
+  canEditPrice: true
 
 - name: anotherOrderItemsSection
   rootComponent: OrderItemsSection

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1339,7 +1339,12 @@
                         }
                     }
                 }
-            ]
+            ],
+            "showPickingSessions": true,
+            "showPurchasedItems": false,
+            "showPickedItems": true,
+            "showClaimItems": false,
+            "canEditPrice": true
         },
         {
             "name": "anotherOrderItemsSection",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1452

**DESCRIPCIÓN DEL REQUERIMIENTO**

Sección ítems comprados:

- Prop showPurchasedItems: true/false default: true

Sección ítems pickeados:

- Prop showPickedItems: true/false default: true
- Prop showClaimItems: true/false default: true
esta prop oculta el header para mostrar los reclamos por pedido, y los reclamos en cada ítem (al momento de escribir el ticket no están desarrollados)

- Prop canEditPrice: true/false default: true(se deberá dejar la validación actual en la que si el pedido esta facturado por mas que este en True, no se deberá poder editar el precio)

Sección sesiones pendientes:

- Prop showPickingSessions: true/false default: true}

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las prop definidas en la descripcion en la seccion de OrderItems

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README