### PR TITLE
add new props for date time picker

### DIFF
--- a/lib/schemas/browse/modules/filters/components/dateTimePicker.js
+++ b/lib/schemas/browse/modules/filters/components/dateTimePicker.js
@@ -3,14 +3,33 @@
 const { makeComponent } = require('../../../../utils');
 const { dateTimePicker } = require('../componentNames');
 
+const booleanType = { type: 'boolean' };
+
 module.exports = makeComponent({
 	name: dateTimePicker,
 	properties: {
-		setStartOfDay: { type: 'boolean' },
-		setEndOfDay: { type: 'boolean' },
-		selectRange: { type: 'boolean' },
-		selectDate: { type: 'boolean' },
-		selectTime: { type: 'boolean' }
+		setStartOfDay: booleanType,
+		setEndOfDay: booleanType,
+		selectRange: booleanType,
+		selectDate: booleanType,
+		selectTime: booleanType,
+		presets: {
+			oneOf: [
+				booleanType,
+				{
+					type: 'object',
+					properties: {
+						today: booleanType,
+						yesterday: booleanType,
+						nextWeek: booleanType,
+						lastWeek: booleanType,
+						lastMonth: booleanType,
+						nextMonth: booleanType
+					},
+					additionalProperties: false
+				}
+			]
+		}
 	},
 	conditions: {
 		if: {

--- a/lib/schemas/edit-new/modules/components/dateTimePicker.js
+++ b/lib/schemas/edit-new/modules/components/dateTimePicker.js
@@ -3,14 +3,33 @@
 const { makeComponent } = require('../../../utils');
 const { dateTimePicker } = require('../componentNames');
 
+const booleanType = { type: 'boolean' };
+
 module.exports = makeComponent({
 	name: dateTimePicker,
 	properties: {
-		setStartOfDay: { type: 'boolean' },
-		setEndOfDay: { type: 'boolean' },
-		selectRange: { type: 'boolean' },
-		selectDate: { type: 'boolean' },
-		selectTime: { type: 'boolean' }
+		setStartOfDay: booleanType,
+		setEndOfDay: booleanType,
+		selectRange: booleanType,
+		selectDate: booleanType,
+		selectTime: booleanType,
+		presets: {
+			oneOf: [
+				booleanType,
+				{
+					type: 'object',
+					properties: {
+						today: booleanType,
+						yesterday: booleanType,
+						nextWeek: booleanType,
+						lastWeek: booleanType,
+						lastMonth: booleanType,
+						nextMonth: booleanType
+					},
+					additionalProperties: false
+				}
+			]
+		}
 	},
 	conditions: {
 		if: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -211,7 +211,24 @@
                 "selectDate": true,
                 "selectRange": true,
                 "setStartOfDay": true,
-                "setEndOfDay": true
+                "setEndOfDay": true,
+                "presets": true
+            }
+        },
+        {
+            "name": "dateTimePickerPresets",
+            "component": "DateTimePicker",
+            "componentAttributes": {
+                "selectDate": true,
+                "selectRange": true,
+                "presets": {
+                    "today": true,
+                    "yesterday": false,
+                    "nextWeek": true,
+                    "lastWeek": false,
+                    "lastMonth": true,
+                    "nextMonth": false
+                }
             }
         },
         {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -594,6 +594,20 @@ sections:
           selectRange: true
           setStartOfDay: true
           setEndOfDay: true
+          presets: true
+
+      - name: dateTimePickerPresets
+        component: DateTimePicker
+        componentAttributes:
+          selectDate: true
+          selectRange: true
+          presets:
+            today: true
+            yesterday: false
+            nextWeek: true
+            lastWeek: false
+            lastMonth: true
+            nextMonth: false
 
       - name: checklist
         component: CheckList

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -213,7 +213,24 @@
                 "selectDate": true,
                 "selectRange": true,
                 "setStartOfDay": true,
-                "setEndOfDay": true
+                "setEndOfDay": true,
+                "presets": true
+            }
+        },
+        {
+            "name": "dateTimePickerPresets",
+            "component": "DateTimePicker",
+            "componentAttributes": {
+                "selectDate": true,
+                "selectRange": true,
+                "presets": {
+                    "today": true,
+                    "yesterday": false,
+                    "nextWeek": true,
+                    "lastWeek": false,
+                    "lastMonth": true,
+                    "nextMonth": false
+                }
             }
         },
         {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -213,7 +213,24 @@
                 "selectDate": true,
                 "selectRange": true,
                 "setStartOfDay": true,
-                "setEndOfDay": true
+                "setEndOfDay": true,
+                "presets": true
+            }
+        },
+        {
+            "name": "dateTimePickerPresets",
+            "component": "DateTimePicker",
+            "componentAttributes": {
+                "selectDate": true,
+                "selectRange": true,
+                "presets": {
+                    "today": true,
+                    "yesterday": false,
+                    "nextWeek": true,
+                    "lastWeek": false,
+                    "lastMonth": true,
+                    "nextMonth": false
+                }
             }
         },
         {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -925,7 +925,24 @@
                                 "selectDate": true,
                                 "selectRange": true,
                                 "setStartOfDay": true,
-                                "setEndOfDay": true
+                                "setEndOfDay": true,
+                                "presets": true
+                            }
+                        },
+                        {
+                            "name": "dateTimePickerPresets",
+                            "component": "DateTimePicker",
+                            "componentAttributes": {
+                                "selectDate": true,
+                                "selectRange": true,
+                                "presets": {
+                                    "today": true,
+                                    "yesterday": false,
+                                    "nextWeek": true,
+                                    "lastWeek": false,
+                                    "lastMonth": true,
+                                    "nextMonth": false
+                                }
                             }
                         },
                         {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1526

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá agregar al componente una property presets para poder determinar desde el schema cual mostrar y cual no, en donde debe esperar 2 props:

boolean donde se agregan todas las opciones
object:
- today: boolean
- yesterday: boolean
- nextWeek: boolean
- lastWeek: boolean
- lastMonth: boolean
- nextMonth: boolean

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron nuevas properties para el Componente de DateTimePicker para filtros y edits/creates forms

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README