### PR TITLE
JMV-1605 add preview component

### DIFF
--- a/lib/schemas/edit-new/modules/componentNames.js
+++ b/lib/schemas/edit-new/modules/componentNames.js
@@ -25,5 +25,6 @@ module.exports = {
 	html: 'HTML',
 	userSelector: 'UserSelector',
 	image: 'Image',
-	userImage: 'UserImage'
+	userImage: 'UserImage',
+	preview: 'Preview'
 };

--- a/lib/schemas/edit-new/modules/components/index.js
+++ b/lib/schemas/edit-new/modules/components/index.js
@@ -16,6 +16,7 @@ const map = require('./map');
 const html = require('./html');
 const userSelector = require('./userSelector');
 const images = require('./images');
+const preview = require('./preview');
 
 module.exports = [
 	selects,
@@ -31,6 +32,7 @@ module.exports = [
 	map,
 	html,
 	userSelector,
+	preview,
 	...images,
 	...chips,
 	...others

--- a/lib/schemas/edit-new/modules/components/preview.js
+++ b/lib/schemas/edit-new/modules/components/preview.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const { preview } = require('../componentNames');
+
+module.exports = makeComponent({
+	name: preview,
+	properties: {
+		image: { type: 'string' },
+		title: { type: 'string' },
+		subtitle: { type: 'string' },
+		description: { type: 'string' },
+		price: { type: 'string' },
+		listPrice: { type: 'string' }
+	}
+});

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -686,7 +686,15 @@ sections:
             method: method
             resolve: false
 
-
+      - name: someFieldPreview
+        component: Preview
+        componentAttributes:
+          image: fieldTitle
+          title: fieldTitle
+          subtitle: fieldSubtitle
+          description: fieldDescription
+          price: fieldPrice
+          listPrice: fieldPrice
 
 - name: semaphoreBrowse
   rootComponent: BrowseSection

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1057,6 +1057,18 @@
                                     "resolve": false
                                 }
                             }
+                        },
+                        {
+                            "name": "someFieldPreview",
+                            "component": "Preview",
+                            "componentAttributes": {
+                                "image": "fieldTitle",
+                                "title": "fieldTitle",
+                                "subtitle": "fieldSubtitle",
+                                "description": "fieldDescription",
+                                "price": "fieldPrice",
+                                "listPrice": "fieldPrice"
+                            }
                         }
                     ]
                 }


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1605

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe crear un nuevo componente de edit/create con el nombre de Preview.
El componente deberá ser lo suficientemente configurable como para mostrar las siguientes cosas:

Imagen
Titulo (nombre del producto)
Subtitulo 
Descripción (doble linea) 
Precio (label y doble value)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se creó un nuevo componente Preview configurable con distintas props descriptas en el ticket.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README