### PR TITLE
JMV-1613 add schema props for triggers

### DIFF
--- a/lib/schemas/edit-new/modules/triggers/triggers.js
+++ b/lib/schemas/edit-new/modules/triggers/triggers.js
@@ -13,9 +13,25 @@ module.exports = {
 				type: 'object',
 				additionalProperties: { type: 'string' }
 			},
+			componentMapping: {
+				type: 'object',
+				additionalProperties: {
+					type: 'object',
+					properties: {
+						root: {
+							type: 'array',
+							items: { type: 'string' },
+							minItems: 1
+						}
+					},
+					additionalProperties: {
+						type: 'string'
+					}
+				}
+			},
 			triggerOnLoad: { type: 'boolean' }
 		},
-		requiredProperties: ['endpoint', 'dataMapping']
+		required: ['endpoint']
 	},
 	minItems: 1
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -468,6 +468,23 @@ sections:
           dataMapping:
             name: firstname
 
+    - name: fieldTriggersTwo
+      component: Input
+      triggers:
+        - endpoint:
+            service: sac
+            namespace: claim
+            method: list
+            resolve: false
+          componentMapping:
+            details:
+              someField: someField
+            other:
+              someField: someField
+              root:
+                - fieldOne
+                - fieldTwo
+
     - name: someInput
       component: Input
       componentAttributes:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -745,6 +745,33 @@
                             ]
                         },
                         {
+                            "name": "fieldTriggersTwo",
+                            "component": "Input",
+                            "componentAttributes": {},
+                            "triggers": [
+                                {
+                                    "endpoint": {
+                                        "service": "sac",
+                                        "namespace": "claim",
+                                        "method": "list",
+                                        "resolve": false
+                                    },
+                                    "componentMapping": {
+                                        "details": {
+                                            "someField": "someField"
+                                        },
+                                        "other": {
+                                            "someField": "someField",
+                                            "root": [
+                                                "fieldOne",
+                                                "fieldTwo"
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "someInput",
                             "component": "Input",
                             "componentAttributes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1613

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar al schema de triggers una nueva props llamada componentMapping.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego al schema de triggers una nueva props llamada componentMapping, y se saco de requerido dataMappding para que sea opcional

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README