### PR TITLE
add new prop for link component path

### DIFF
--- a/lib/schemas/browse/modules/components/link.js
+++ b/lib/schemas/browse/modules/components/link.js
@@ -11,6 +11,7 @@ module.exports = makeComponent({
 		label: { type: 'string' },
 		labelField: { type: 'string' },
 		target: { type: 'string' },
+		path: { type: 'string' },
 		urlTarget: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		endpointParameters: getStaticFilters()
 	}

--- a/lib/schemas/edit-new/modules/components/link.js
+++ b/lib/schemas/edit-new/modules/components/link.js
@@ -11,6 +11,7 @@ module.exports = makeComponent({
 		label: { type: 'string' },
 		labelField: { type: 'string' },
 		target: { type: 'string' },
+		path: { type: 'string' },
 		urlTarget: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		endpointParameters: getStaticFilters()
 	}

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -443,6 +443,13 @@
             "name": "linkTest3",
             "component": "Link",
             "componentAttributes": {
+                "path": "/some/path/{id}"
+            }
+        },
+        {
+            "name": "linkTest4",
+            "component": "Link",
+            "componentAttributes": {
                 "urlTarget": {
                     "service": "service",
                     "namespace": "namespace",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -471,6 +471,11 @@ sections:
     - name: linkTest3
       component: Link
       componentAttributes:
+        path: /some/path/{id}
+
+    - name: linkTest4
+      component: Link
+      componentAttributes:
         urlTarget:
           service: service
           namespace: namespace

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -557,6 +557,19 @@
                 "initialSortDirection": "desc"
             },
             "componentAttributes": {
+                "path": "/some/path/{id}"
+            }
+        },
+        {
+            "name": "linkTest4",
+            "component": "Link",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
                 "urlTarget": {
                     "service": "service",
                     "namespace": "namespace",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -557,6 +557,19 @@
                 "initialSortDirection": "desc"
             },
             "componentAttributes": {
+                "path": "/some/path/{id}"
+            }
+        },
+        {
+            "name": "linkTest4",
+            "component": "Link",
+            "attributes": {
+                "isStatus": false,
+                "sortable": false,
+                "isDefaultSort": false,
+                "initialSortDirection": "desc"
+            },
+            "componentAttributes": {
                 "urlTarget": {
                     "service": "service",
                     "namespace": "namespace",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -742,6 +742,13 @@
                             "name": "linkTest3",
                             "component": "Link",
                             "componentAttributes": {
+                                "path": "/some/path/{id}"
+                            }
+                        },
+                        {
+                            "name": "linkTest4",
+                            "component": "Link",
+                            "componentAttributes": {
                                 "urlTarget": {
                                     "service": "service",
                                     "namespace": "namespace",


### PR DESCRIPTION
LINK AL TICKET

https://fizzmod.atlassian.net/browse/JMV-1684

DESCRIPCIÓN DEL REQUERIMIENTO

Se deberá agregar una nueva prop de componentAttributes a los componentes de Link
 - path: string

DESCRIPCIÓN DE LA SOLUCIÓN

Se agregó la nueva prop a los schemas de los componentes Link

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README