### PR TITLE
add new props for sort endpoint field param

### DIFF
--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -44,6 +44,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 			minItems: 1
 		},
 		sortEndpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		fieldSortEndpoint: { string: 'string' },
 		staticFilters: getStaticFilters(isPage),
 		hasPreview: { type: 'boolean', default: false },
 		canEdit: { type: 'boolean', default: true },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -16,6 +16,7 @@
         "method": "method",
         "resolve": false
     },
+    "fieldSortEndpoint": "id",
     "appearance": {
         "desktop": {
             "rowMinHeight": 70,

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -14,6 +14,7 @@
         "method": "method",
         "resolve": false
     },
+    "fieldSortEndpoint": "id",
     "appearance": {
         "desktop": {
             "rowMinHeight": 70,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -14,6 +14,7 @@
         "method": "method",
         "resolve": false
     },
+    "fieldSortEndpoint": "id",
     "appearance": {
         "desktop": {
             "rowMinHeight": 70,


### PR DESCRIPTION
DESCRIPCIÓN DEL REQUERIMIENTO

Se deberá agregar al schema de los  browses una nueva prop para definir un el nombre de un campo a tomar para interpolar en la url de sortEndpoint.

CÓMO SE PUEDE PROBAR?

Ejecutando comando de validacion de package descripto en el README