### PR TITLE
JMV-1711 add canImport  prop

### DIFF
--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -9,6 +9,7 @@ module.exports = {
 	properties: {
 		...properties,
 		...getBrowseBaseSchema(true),
+		canImport: { type: 'boolean' },
 		root: { const: 'Browse' },
 		actions
 	},

--- a/lib/schemas/common/browseBase.js
+++ b/lib/schemas/common/browseBase.js
@@ -44,7 +44,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 			minItems: 1
 		},
 		sortEndpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-		fieldSortEndpoint: { string: 'string' },
+		fieldSortEndpoint: { type: 'string' },
 		staticFilters: getStaticFilters(isPage),
 		hasPreview: { type: 'boolean', default: false },
 		canEdit: { type: 'boolean', default: true },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -3,6 +3,7 @@
     "name": "claim-type-browse",
     "root": "Browse",
     "canExport": true,
+    "canImport": true,
     "canRefresh": false,
     "source": {
         "service": "sac",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -832,10 +832,12 @@ sections:
 - name: semaphoreBrowse
   rootComponent: BrowseSection
   canRefresh: true
+
   conditions:
     showWhen:
       - - name: isNotEmpty
           field: order
+
   topComponents:
     - component: TestComponent
       attributes:
@@ -850,11 +852,15 @@ sections:
     namespace: claim-semaphore
     method: browse
     resolve: false
+
   sortEndpoint:
     service: service
     namespace: namespace
     method: method
     resolve: false
+
+  fieldSortEndpoint: id
+
   appearance:
     default:
       rowMinHeight: 50

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -1523,6 +1523,7 @@
     "canEdit": true,
     "canCreate": true,
     "canExport": true,
+    "canImport": true,
     "canView": false,
     "canRefresh": false,
     "pageSize": 60

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -1523,6 +1523,7 @@
     "canEdit": true,
     "canCreate": true,
     "canExport": true,
+    "canImport": true,
     "canView": false,
     "canRefresh": false,
     "pageSize": 60,

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1311,6 +1311,7 @@
                 "method": "method",
                 "resolve": false
             },
+            "fieldSortEndpoint": "id",
             "appearance": {
                 "default": {
                     "rowMinHeight": 50


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1711

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá agregar la property *canImport* en el schema del browse

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó una nueva prop al schema de la pagina de browse.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README