### PR TITLE
add new prop for dateTimePicker

### DIFF
--- a/lib/schemas/browse/modules/filters/components/dateTimePicker.js
+++ b/lib/schemas/browse/modules/filters/components/dateTimePicker.js
@@ -13,6 +13,7 @@ module.exports = makeComponent({
 		selectRange: booleanType,
 		selectDate: booleanType,
 		selectTime: booleanType,
+		format: { type: 'string' },
 		presets: {
 			oneOf: [
 				booleanType,

--- a/lib/schemas/edit-new/modules/components/dateTimePicker.js
+++ b/lib/schemas/edit-new/modules/components/dateTimePicker.js
@@ -13,6 +13,7 @@ module.exports = makeComponent({
 		selectRange: booleanType,
 		selectDate: booleanType,
 		selectTime: booleanType,
+		format: { type: 'string' },
 		presets: {
 			oneOf: [
 				booleanType,

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -248,7 +248,8 @@
             "componentAttributes": {
                 "selectDate": false,
                 "selectTime": true,
-                "selectRange": true
+                "selectRange": true,
+                "format": "hh:mm"
             }
         },
         {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -755,6 +755,7 @@ sections:
           selectDate: false
           selectTime: true
           selectRange: true
+          format: hh:mm
 
       - name: otherDateTime
         component: DateTimePicker

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -250,7 +250,8 @@
             "componentAttributes": {
                 "selectDate": false,
                 "selectTime": true,
-                "selectRange": true
+                "selectRange": true,
+                "format": "hh:mm"
             }
         },
         {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -250,7 +250,8 @@
             "componentAttributes": {
                 "selectDate": false,
                 "selectTime": true,
-                "selectRange": true
+                "selectRange": true,
+                "format": "hh:mm"
             }
         },
         {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1186,7 +1186,8 @@
                             "componentAttributes": {
                                 "selectDate": false,
                                 "selectTime": true,
-                                "selectRange": true
+                                "selectRange": true,
+                                "format": "hh:mm"
                             }
                         },
                         {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1801

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá agregar al DateTimePicker la prop opcional format para definir la string con el formato con el que debe enviarse la data. 

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego al schema de los dateTimePicker una nueva prop llamada format tipo string

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README