### PR TITLE
add new props for form sections

### DIFF
--- a/lib/schemas/edit-new/modules/sections/formSection.js
+++ b/lib/schemas/edit-new/modules/sections/formSection.js
@@ -19,7 +19,9 @@ module.exports = {
 			target: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 			targetEndpointParameters: getStaticFilters(),
 			sourceEndpointParameters: getStaticFilters(),
-			fieldsGroup
+			fieldsGroup,
+			hideUserCreated: { type: 'boolean' },
+			hideUserModified: { type: 'boolean' }
 		},
 		required: ['name', 'rootComponent', 'fieldsGroup', 'source'],
 		additionalProperties: false

--- a/lib/schemas/edit-new/modules/sections/mainForm.js
+++ b/lib/schemas/edit-new/modules/sections/mainForm.js
@@ -14,7 +14,9 @@ module.exports = {
 			title: { type: 'string' },
 			name: { type: 'string', const: 'mainFormSection' },
 			rootComponent: { type: 'string', const: mainForm },
-			fieldsGroup
+			fieldsGroup,
+			hideUserCreated: { type: 'boolean' },
+			hideUserModified: { type: 'boolean' }
 		},
 		required: ['name', 'rootComponent', 'fieldsGroup'],
 		additionalProperties: false

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -92,6 +92,8 @@ sections:
 - name: mainFormSection
   rootComponent: MainForm
   icon: catalogue
+  hideUserModified: false
+  hideUserCreated: true
   topComponents:
     - component: TestComponent
     - component: TestComponentLeft
@@ -1131,6 +1133,8 @@ sections:
 
 - name: testFormSection
   rootComponent: FormSection
+  hideUserModified: false
+  hideUserCreated: true
   source:
     service: sac
     namespace: claim-motive

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -133,6 +133,8 @@
             "name": "mainFormSection",
             "rootComponent": "MainForm",
             "icon": "catalogue",
+            "hideUserModified": false,
+            "hideUserCreated": true,
             "topComponents": [
                 {
                     "component": "TestComponent"
@@ -1795,6 +1797,8 @@
         {
             "name": "testFormSection",
             "rootComponent": "FormSection",
+            "hideUserModified": false,
+            "hideUserCreated": true,
             "source": {
                 "service": "sac",
                 "namespace": "claim-motive",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1915

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberán agregar dos nuevas properties para ocultar información de usuario creador y modificados de los form sections.
Las properties deberán ser:
- hideUserCreated (boolean)
- hideUserModified (boolean)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las dos nuevas props a los schemas de las secciones de mainForm y formSection

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README