### PR TITLE
add topComponents in browse page

### DIFF
--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -3,6 +3,7 @@
 const { properties, required } = require('../common/base');
 const actions = require('../common/actions');
 const getBrowseBaseSchema = require('../common/browseBase');
+const makeTopComponents = require('../common/topComponents');
 
 module.exports = {
 	type: 'object',
@@ -11,7 +12,8 @@ module.exports = {
 		...getBrowseBaseSchema(true),
 		canImport: { type: 'boolean' },
 		root: { const: 'Browse' },
-		actions
+		actions,
+		topComponents: makeTopComponents(true)
 	},
 	additionalProperties: false,
 	required: [...required, 'fields', 'source']

--- a/lib/schemas/common/topComponents.js
+++ b/lib/schemas/common/topComponents.js
@@ -1,20 +1,25 @@
 'use strict';
 
-const action = require('../../../../common/actions/action');
-const makeConditions = require('../../../../common/conditions');
+const action = require('./actions/action');
+const makeConditions = require('./conditions');
 
-const availableCallbacks = ['reloadSectionData', 'refresh'];
+// Edit page section topComponents callbacks
+const sectionCallbacks = ['reloadSectionData', 'refresh'];
+// Browse page topComponents callbacks
+const pageCallbacks = ['reloadBrowse', 'refresh'];
 
-const customAction = {
+const conditions = makeConditions();
+
+const makeCustomAction = isBrowsePage => ({
 	...action,
 	properties: {
 		...action.properties,
-		conditions: makeConditions(),
+		conditions,
 		callback: {
-			enum: availableCallbacks
+			enum: isBrowsePage ? pageCallbacks : sectionCallbacks
 		}
 	}
-};
+});
 
 /** Common properties for TopComponent */
 const commonProperties = {
@@ -26,7 +31,7 @@ const commonProperties = {
 		type: 'object',
 		additionalProperties: true
 	},
-	conditions: makeConditions()
+	conditions
 };
 
 /** Top components with especial properties */
@@ -35,8 +40,7 @@ const specialTopComponents = {
 	actionForm: 'ActionForm'
 };
 
-
-module.exports = {
+const makeTopComponents = (isBrowsePage = false) => ({
 	type: 'array',
 	items: {
 		type: 'object',
@@ -55,7 +59,7 @@ module.exports = {
 						component: { const: specialTopComponents.actionButtons },
 						actions: {
 							type: 'array',
-							items: customAction
+							items: makeCustomAction(isBrowsePage)
 						},
 						...commonProperties
 					},
@@ -113,4 +117,6 @@ module.exports = {
 		]
 	},
 	minItems: 1
-};
+});
+
+module.exports = makeTopComponents;

--- a/lib/schemas/edit-new/modules/sections/commonProperties.js
+++ b/lib/schemas/edit-new/modules/sections/commonProperties.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const topComponents = require('./components/topComponents');
+const makeTopComponents = require('../../../common/topComponents');
 const makeConditions = require('../../../common/conditions');
 
 module.exports = {
-	topComponents,
+	topComponents: makeTopComponents(),
 	includeDataFrom: {
 		type: 'array',
 		items: { type: 'string' },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -77,6 +77,37 @@
             }
         }
     },
+    "topComponents": [
+        {
+            "component": "TestComponent",
+            "attributes": {
+                "name": "test",
+                "sarasa": "test23"
+            }
+        },
+        {
+            "component": "TestComponent2",
+            "attributes": {
+                "name": "test",
+                "sarasa": "test23"
+            }
+        },
+        {
+            "component": "ActionButtons",
+            "position": "right",
+            "actions": [
+                {
+                    "name": "new",
+                    "icon": "star_light",
+                    "color": "fizzGreen",
+                    "type": "link",
+                    "options": {
+                        "path": "/service/namespace/new"
+                    }
+                }
+            ]
+        }
+    ],
     "sortableFields": [
         {
             "name": "test"

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -908,6 +908,17 @@ sections:
       attributes:
         name: test
         sarasa: test23
+
+    - component: ActionButtons
+      position: right
+      actions:
+        - name: new
+          icon: star_light
+          color: fizzGreen
+          type: link
+          options:
+            path: /service/namespace/new
+
   source:
     service: sac
     namespace: claim-semaphore

--- a/tests/mocks/schemas/expected/browse-not-actions.json
+++ b/tests/mocks/schemas/expected/browse-not-actions.json
@@ -71,6 +71,37 @@
             }
         }
     },
+    "topComponents": [
+        {
+            "component": "TestComponent",
+            "attributes": {
+                "name": "test",
+                "sarasa": "test23"
+            }
+        },
+        {
+            "component": "TestComponent2",
+            "attributes": {
+                "name": "test",
+                "sarasa": "test23"
+            }
+        },
+        {
+            "component": "ActionButtons",
+            "position": "right",
+            "actions": [
+                {
+                    "name": "new",
+                    "icon": "star_light",
+                    "color": "fizzGreen",
+                    "type": "link",
+                    "options": {
+                        "path": "/service/namespace/new"
+                    }
+                }
+            ]
+        }
+    ],
     "sortableFields": [
         {
             "name": "test",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -71,6 +71,37 @@
             }
         }
     },
+    "topComponents": [
+        {
+            "component": "TestComponent",
+            "attributes": {
+                "name": "test",
+                "sarasa": "test23"
+            }
+        },
+        {
+            "component": "TestComponent2",
+            "attributes": {
+                "name": "test",
+                "sarasa": "test23"
+            }
+        },
+        {
+            "component": "ActionButtons",
+            "position": "right",
+            "actions": [
+                {
+                    "name": "new",
+                    "icon": "star_light",
+                    "color": "fizzGreen",
+                    "type": "link",
+                    "options": {
+                        "path": "/service/namespace/new"
+                    }
+                }
+            ]
+        }
+    ],
     "sortableFields": [
         {
             "name": "test",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1454,6 +1454,21 @@
                         "name": "test",
                         "sarasa": "test23"
                     }
+                },
+                {
+                    "component": "ActionButtons",
+                    "position": "right",
+                    "actions": [
+                        {
+                            "name": "new",
+                            "icon": "star_light",
+                            "color": "fizzGreen",
+                            "type": "link",
+                            "options": {
+                                "path": "/service/namespace/new"
+                            }
+                        }
+                    ]
                 }
             ],
             "fields": [


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1943

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá implementar la funcionalidad de los topComponents tanto en el browse como en el browseSection

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego a los browses en general una nueva prop de topComponents, se hizo un pequeño refactor de topComponents para su mejor uso. Se agrego un callback nuevo para las acciones en un browse ('reloadBrowse')

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README