### PR TITLE
add asyncwrapper form new prop

### DIFF
--- a/lib/schemas/edit-new/modules/components/asyncWrapper.js
+++ b/lib/schemas/edit-new/modules/components/asyncWrapper.js
@@ -3,19 +3,31 @@
 const { makeComponent } = require('../../../utils');
 const { asyncWrapper } = require('../componentNames');
 
+const endpointParameters = { $ref: 'schemaDefinitions#/definitions/endpointParameters' };
+const dataMapping = { type: 'object', additionalProperties: { type: 'string' } };
+const targetField = { type: 'string' };
+
 module.exports = makeComponent({
 	name: asyncWrapper,
 	properties: {
+		dataMapping,
+		targetField,
+		endpointParameters,
+		staticFilters: endpointParameters,
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-		dataMapping: {
-			type: 'object',
-			additionalProperties: { type: 'string' }
-		},
-		field: {
-			$ref: 'schemaDefinitions#/definitions/editNewField'
-		},
-		staticFilters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
-		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
+		field: { $ref: 'schemaDefinitions#/definitions/editNewField' }
 	},
-	requiredProperties: ['dataMapping', 'source', 'field']
+	conditions: {
+		anyOf: [
+			{
+				required: ['dataMapping'],
+				properties: { dataMapping }
+			},
+			{
+				required: ['targetField'],
+				properties: { targetField }
+			}
+		]
+	},
+	requiredProperties: ['source', 'field']
 });

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -480,7 +480,7 @@ sections:
     - name: exampleMapThree
       component: Map
 
-    - name: asyncData
+    - name: asyncWrapperExampleOne
       component: AsyncWrapper
       componentAttributes:
         endpointParameters:
@@ -501,6 +501,24 @@ sections:
           firstname: userFirstname
         field:
           name: userFirstname
+          component: Text
+
+    - name: asyncWrapperExampleTwo
+      component: AsyncWrapper
+      componentAttributes:
+        endpointParameters:
+          - name: id
+            target: query
+            value:
+              dynamic: userIds
+        source:
+          service: id
+          namespace: user
+          method: list
+          resolve: false
+        targetField: users
+        field:
+          name: users
           component: Text
 
     - name: linkTest1

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -768,7 +768,7 @@
                             "componentAttributes": {}
                         },
                         {
-                            "name": "asyncData",
+                            "name": "asyncWrapperExampleOne",
                             "component": "AsyncWrapper",
                             "componentAttributes": {
                                 "endpointParameters": [
@@ -798,6 +798,33 @@
                                 },
                                 "field": {
                                     "name": "userFirstname",
+                                    "component": "Text",
+                                    "componentAttributes": {}
+                                }
+                            }
+                        },
+                        {
+                            "name": "asyncWrapperExampleTwo",
+                            "component": "AsyncWrapper",
+                            "componentAttributes": {
+                                "endpointParameters": [
+                                    {
+                                        "name": "id",
+                                        "target": "query",
+                                        "value": {
+                                            "dynamic": "userIds"
+                                        }
+                                    }
+                                ],
+                                "source": {
+                                    "service": "id",
+                                    "namespace": "user",
+                                    "method": "list",
+                                    "resolve": false
+                                },
+                                "targetField": "users",
+                                "field": {
+                                    "name": "users",
                                     "component": "Text",
                                     "componentAttributes": {}
                                 }


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-1941

**DESCRIPCIÓN DEL REQUERIMIENTO**

Agregar prop targetField(string) al schema de AsyncWrapper de forms

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego al schema de asyncWrapper de forms una nueva prop targetField, y se refactorizo un poco para su mejor funcionamiento.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README