### PR TITLE
Jmv 2065 location component

### DIFF
--- a/lib/schemas/edit-new/modules/componentNames.js
+++ b/lib/schemas/edit-new/modules/componentNames.js
@@ -29,5 +29,6 @@ module.exports = {
 	iconSelector: 'IconSelector',
 	preview: 'Preview',
 	selectForm: 'SelectForm',
-	objectCreator: 'ObjectCreator'
+	objectCreator: 'ObjectCreator',
+	location: 'Location'
 };

--- a/lib/schemas/edit-new/modules/components/index.js
+++ b/lib/schemas/edit-new/modules/components/index.js
@@ -20,6 +20,7 @@ const iconSelector = require('./iconSelector');
 const preview = require('./preview');
 const selectForm = require('./selectForm');
 const objectCreator = require('./objectCreator');
+const location = require('./location');
 
 module.exports = [
 	selects,
@@ -39,6 +40,7 @@ module.exports = [
 	preview,
 	selectForm,
 	objectCreator,
+	location,
 	...images,
 	...chips,
 	...others

--- a/lib/schemas/edit-new/modules/components/location.js
+++ b/lib/schemas/edit-new/modules/components/location.js
@@ -30,7 +30,7 @@ module.exports = makeComponent({
 				latitude: { type: 'string' },
 				longitude: { type: 'string' }
 			},
-			minProperties: 1,
+			minProperties: 2,
 			additionalProperties: false
 		}
 	},

--- a/lib/schemas/edit-new/modules/components/location.js
+++ b/lib/schemas/edit-new/modules/components/location.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const { location } = require('../componentNames');
+
+module.exports = makeComponent({
+	name: location,
+	properties: {
+		label: {
+			oneOf: [
+				{ type: 'string' },
+				{
+					type: 'object',
+					properties: {
+						template: { type: 'string' },
+						fields: {
+							type: 'array',
+							items: { type: 'string' },
+							minItems: 1
+						}
+					},
+					required: ['template', 'fields'],
+					additionalProperties: false
+				}
+			]
+		},
+		fieldsMapping: {
+			type: 'object',
+			properties: {
+				latitude: { type: 'string' },
+				longitude: { type: 'string' }
+			},
+			minProperties: 1,
+			additionalProperties: false
+		}
+	},
+	requiredProperties: ['label']
+});

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -507,6 +507,23 @@ sections:
     - name: exampleMapThree
       component: Map
 
+    - name: exampleLocationOne
+      component: Location
+      componentAttributes:
+        label: some.traduction.label
+        fieldsMapping:
+          latitude: lat
+          longitude: lng
+
+    - name: exampleLocationTwo
+      component: Location
+      componentAttributes:
+        label:
+          template: '{0} {1}'
+          fields:
+            - address
+            - country
+
     - name: asyncWrapperExampleOne
       component: AsyncWrapper
       componentAttributes:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -806,6 +806,27 @@
                             "componentAttributes": {}
                         },
                         {
+                            "name": "exampleLocationOne",
+                            "component": "Location",
+                            "componentAttributes": {
+                                "label": "some.traduction.label",
+                                "fieldsMapping": {
+                                    "latitude": "lat",
+                                    "longitude": "lng"
+                                }
+                            }
+                        },
+                        {
+                            "name": "exampleLocationTwo",
+                            "component": "Location",
+                            "componentAttributes": {
+                                "label": {
+                                    "template": "{0} {1}",
+                                    "fields": ["address", "country"]
+                                }
+                            }
+                        },
+                        {
                             "name": "asyncWrapperExampleOne",
                             "component": "AsyncWrapper",
                             "componentAttributes": {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2065

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar componente Location para que tenga en componentAttributes lo siguiente
- label:  requerido (string|object)
- - Con label tipo string traducible o tipo template(object)
- fieldsMapping: opcional (object)
- - latitude : requerido (string)
- - longitude requerido (string)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agrego el nuevo componente a los Forms y para los fieldGroup en general que usan summary

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README