### PR TITLE
add labelMapper for Links

### DIFF
--- a/lib/schemas/browse/modules/components/link.js
+++ b/lib/schemas/browse/modules/components/link.js
@@ -2,6 +2,7 @@
 
 const { makeComponent } = require('../../../utils');
 const { link } = require('../componentNames');
+const mapper = require('../../../common/mapper');
 
 module.exports = makeComponent({
 	name: link,
@@ -9,6 +10,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		label: { type: 'string' },
 		labelField: { type: 'string' },
+		labelMapper: mapper,
 		target: { type: 'string' },
 		path: { type: 'string' },
 		urlTarget: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/lib/schemas/edit-new/modules/components/link.js
+++ b/lib/schemas/edit-new/modules/components/link.js
@@ -2,6 +2,7 @@
 
 const { makeComponent } = require('../../../utils');
 const { link } = require('../componentNames');
+const mapper = require('../../../common/mapper');
 
 module.exports = makeComponent({
 	name: link,
@@ -9,6 +10,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		label: { type: 'string' },
 		labelField: { type: 'string' },
+		labelMapper: mapper,
 		target: { type: 'string' },
 		path: { type: 'string' },
 		urlTarget: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -737,7 +737,8 @@
                 "translateLabels": true,
                 "labelField": "label",
                 "label": "test",
-                "target": "_self"
+                "target": "_self",
+                "labelMapper": "addHashtag"
             }
         },
         {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -620,6 +620,7 @@ sections:
         translateLabels: true
         label: test.test.test
         labelField: asdasd
+        labelMapper: addHashtag
 
     - name: linkTest3
       component: Link

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -893,7 +893,8 @@
                 "translateLabels": true,
                 "labelField": "label",
                 "label": "test",
-                "target": "_self"
+                "target": "_self",
+                "labelMapper": "addHashtag"
             }
         },
         {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -973,7 +973,8 @@
                                 "target": "_blank",
                                 "translateLabels": true,
                                 "label": "test.test.test",
-                                "labelField": "asdasd"
+                                "labelField": "asdasd",
+                                "labelMapper": "addHashtag"
                             }
                         },
                         {

--- a/tests/mocks/schemas/expected/preview.json
+++ b/tests/mocks/schemas/expected/preview.json
@@ -158,6 +158,7 @@
                             "component": "Link",
                             "componentAttributes": {
                                 "translateLabels": false,
+                                "labelMapper": "addHashtag",
                                 "path": "/playground/views-demo/{id}",
                                 "endpointParameters": [
                                     {

--- a/tests/mocks/schemas/preview.yml
+++ b/tests/mocks/schemas/preview.yml
@@ -104,6 +104,7 @@ sections:
       component: Link
       componentAttributes:
         translateLabels: false
+        labelMapper: addHashtag
         path: "/playground/views-demo/{id}"
         endpointParameters:
         - name: id


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2216

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar a los componentAttributes del componente Link la compatibilidad con la nueva prop labelMapper (que funciona igual que la prop mapper).

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó la prop de labelMapper a los componentes de Link.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README