### PR TITLE
add defaultTitle header component

### DIFF
--- a/lib/schemas/edit-new/modules/headerProperties.js
+++ b/lib/schemas/edit-new/modules/headerProperties.js
@@ -5,8 +5,36 @@ const mapper = require('../../common/mapper');
 const { badgeLetter, statusChip } = require('../../browse/modules/componentNames');
 const { makeComponent } = require('../../utils');
 
+const identifier = {
+	oneOf: [
+		{ type: 'string' },
+		{
+			type: 'array',
+			items: { type: 'string' },
+			minItems: 1
+		},
+		{
+			type: 'object',
+			properties: {
+				template: { type: 'string' },
+				fields: {
+					type: 'array',
+					items: { type: 'string' },
+					minItems: 1
+				}
+			},
+			required: ['template', 'fields'],
+			additionalProperties: false
+		}
+	]
+};
+
 const additionalComponents = [
 	{ name: 'IdText' },
+	{
+		name: 'DefaultTitle',
+		properties: { identifier }
+	},
 	{
 		name: 'CustomTitle',
 		properties: {
@@ -24,7 +52,15 @@ const componentsProps = {
 		type: 'object',
 		properties: {
 			name: { type: 'string' },
-			component: { enum: [badgeLetter, statusChip, 'IdText', 'CustomTitle'] },
+			component: {
+				enum: [
+					badgeLetter,
+					statusChip,
+					'IdText',
+					'DefaultTitle',
+					'CustomTitle'
+				]
+			},
 			mapper,
 			componentAttributes: {
 				type: 'object',
@@ -46,26 +82,7 @@ module.exports = {
 				components: componentsProps,
 				afterId: componentsProps,
 				beforeId: componentsProps,
-				identifier: {
-					oneOf: [
-						{ type: 'string' },
-						{
-							type: 'object',
-							properties: {
-								template: { type: 'string' },
-								fields: {
-									type: 'array',
-									items: {
-										type: 'string'
-									},
-									minItems: 1
-								}
-							},
-							required: ['template', 'fields'],
-							additionalProperties: false
-						}
-					]
-				}
+				identifier
 			},
 			minProperties: 1,
 			additionalProperties: false

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -32,6 +32,10 @@ header:
         componentAttributes:
           value: some.traduction
           color: red
+      - name: someTitle
+        component: DefaultTitle
+        componentAttributes:
+          identifier: someFieldName
 
 themes:
   themeOne:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -46,6 +46,13 @@
                         "value": "some.traduction",
                         "color": "red"
                     }
+                },
+                {
+                    "name": "someTitle",
+                    "component": "DefaultTitle",
+                    "componentAttributes": {
+                        "identifier": "someFieldName"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2221

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar un nuevo componente para el header de edit/preview.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó a los componentes de header de edit/preview un nuevo componente `DefaultTitle` al que se le puede pasar por componenentAttrbutes la prop de `identifier`.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README