### PR TITLE
add translateLabel prop in fields

### DIFF
--- a/lib/schemas/browse/modules/field.js
+++ b/lib/schemas/browse/modules/field.js
@@ -15,6 +15,7 @@ module.exports = {
 		name: { type: 'string' },
 		label: { type: 'string' },
 		noLabel: { type: 'boolean' },
+		translateLabels: { type: 'boolean' },
 		dependency: { type: 'string' },
 		deviceDisplay: { enum: ['desktop', 'mobile'] },
 		showOnPreview: { type: 'boolean' },

--- a/lib/schemas/browse/modules/field.js
+++ b/lib/schemas/browse/modules/field.js
@@ -15,7 +15,7 @@ module.exports = {
 		name: { type: 'string' },
 		label: { type: 'string' },
 		noLabel: { type: 'boolean' },
-		translateLabels: { type: 'boolean' },
+		translateLabel: { type: 'boolean' },
 		dependency: { type: 'string' },
 		deviceDisplay: { enum: ['desktop', 'mobile'] },
 		showOnPreview: { type: 'boolean' },

--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -16,7 +16,7 @@ module.exports = {
 		label: { type: 'string' },
 		placeholder: { type: 'string' },
 		noLabel: { type: 'boolean' },
-		translateLabels: { type: 'boolean' },
+		translateLabel: { type: 'boolean' },
 		dependency: { type: 'string' },
 		width: { type: 'number' },
 		position: { type: 'string', enum: ['left', 'right'] },

--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -16,6 +16,7 @@ module.exports = {
 		label: { type: 'string' },
 		placeholder: { type: 'string' },
 		noLabel: { type: 'boolean' },
+		translateLabels: { type: 'boolean' },
 		dependency: { type: 'string' },
 		width: { type: 'number' },
 		position: { type: 'string', enum: ['left', 'right'] },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -617,7 +617,7 @@
         },
         {
             "name": "customerList",
-            "translateLabels": false,
+            "translateLabel": false,
             "component": "Text",
             "mapper": {
                 "name": "arrayMap",

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -617,6 +617,7 @@
         },
         {
             "name": "customerList",
+            "translateLabels": false,
             "component": "Text",
             "mapper": {
                 "name": "arrayMap",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -387,6 +387,7 @@ sections:
         fontWeight: normal
 
     - name: exampleImage
+      translateLabels: false
       component: Image
 
     - name: exampleImageWithProps
@@ -1515,6 +1516,7 @@ sections:
 
           fields:
             - name: someField
+              translateLabels: false
               component: Text
 
             - name: linkField

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -387,7 +387,7 @@ sections:
         fontWeight: normal
 
     - name: exampleImage
-      translateLabels: false
+      translateLabel: false
       component: Image
 
     - name: exampleImageWithProps
@@ -1516,7 +1516,7 @@ sections:
 
           fields:
             - name: someField
-              translateLabels: false
+              translateLabel: false
               component: Text
 
             - name: linkField

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -664,6 +664,7 @@
         },
         {
             "name": "customerList",
+            "translateLabels": false,
             "component": "Text",
             "attributes": {
                 "isStatus": false,

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -664,7 +664,7 @@
         },
         {
             "name": "customerList",
-            "translateLabels": false,
+            "translateLabel": false,
             "component": "Text",
             "attributes": {
                 "isStatus": false,

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -612,7 +612,7 @@
                         {
                             "name": "exampleImage",
                             "component": "Image",
-                            "translateLabels": false,
+                            "translateLabel": false,
                             "componentAttributes": {
                                 "roundBorders": false,
                                 "width": "auto",
@@ -2445,7 +2445,7 @@
                                 {
                                     "name": "someField",
                                     "component": "Text",
-                                    "translateLabels": false,
+                                    "translateLabel": false,
                                     "componentAttributes": {}
                                 },
                                 {

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -612,6 +612,7 @@
                         {
                             "name": "exampleImage",
                             "component": "Image",
+                            "translateLabels": false,
                             "componentAttributes": {
                                 "roundBorders": false,
                                 "width": "auto",
@@ -2444,6 +2445,7 @@
                                 {
                                     "name": "someField",
                                     "component": "Text",
+                                    "translateLabels": false,
                                     "componentAttributes": {}
                                 },
                                 {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2271

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá generar una nueva property en los fields para evitar que se traduzcan los labels de los mismos
La property se deberá llamar transalateLabels: true/false
- El default deberá seguir siendo true

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó la prop translateLabels en los fields de browse, form y demás sections.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README