### PR TITLE
add canClear prop to some selectors

### DIFF
--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -10,6 +10,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		labelPrefix: { type: 'string' },
 		canClear: { type: 'boolean' },
+		canCreate: { type: 'boolean' },
 		icon: { type: 'string' },
 		preloadOptions: { type: 'boolean' },
 		options: {

--- a/lib/schemas/browse/modules/filters/components/userSelector.js
+++ b/lib/schemas/browse/modules/filters/components/userSelector.js
@@ -8,6 +8,7 @@ module.exports = makeComponent({
 	properties: {
 		isMulti: { type: 'boolean' },
 		onlyActiveUsers: { type: 'boolean' },
+		canClear: { type: 'boolean' },
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' }
 	}
 });

--- a/lib/schemas/edit-new/modules/components/iconSelector.js
+++ b/lib/schemas/edit-new/modules/components/iconSelector.js
@@ -4,5 +4,8 @@ const { makeComponent } = require('../../../utils');
 const { iconSelector } = require('../componentNames');
 
 module.exports = makeComponent({
-	name: iconSelector
+	name: iconSelector,
+	properties: {
+		canClear: { type: 'boolean' }
+	}
 });

--- a/lib/schemas/edit-new/modules/components/userSelector.js
+++ b/lib/schemas/edit-new/modules/components/userSelector.js
@@ -9,6 +9,7 @@ module.exports = makeComponent({
 		isMulti: { type: 'boolean' },
 		onlyActiveUsers: { type: 'boolean' },
 		canCreate: { type: 'boolean' },
+		canClear: { type: 'boolean' },
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' }
 	}
 });

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -914,6 +914,7 @@ sections:
         componentAttributes:
           translateLabels: true
           parentFilterName: parent
+          canClear: true
           maxLevel: 3
           options:
             scope: remote
@@ -1027,13 +1028,19 @@ sections:
       - name: userAssigned
         component: UserSelector
 
-      - name: fieldIconSelector
+      - name: fieldIconSelectorOne
         component: IconSelector
+
+      - name: fieldIconSelectorTwo
+        component: IconSelector
+        componentAttributes:
+          canClear: true
 
       - name: members
         component: UserSelector
         componentAttributes:
           isMulti: true
+          canClear: true
           onlyActiveUsers: true
           source:
             service: service

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1411,6 +1411,7 @@
                             "componentAttributes": {
                                 "translateLabels": true,
                                 "parentFilterName": "parent",
+                                "canClear": true,
                                 "maxLevel": 3,
                                 "options": {
                                     "scope": "remote",
@@ -1564,15 +1565,23 @@
                             "componentAttributes": {}
                         },
                         {
-                            "name": "fieldIconSelector",
+                            "name": "fieldIconSelectorOne",
                             "component": "IconSelector",
                             "componentAttributes": {}
+                        },
+                        {
+                            "name": "fieldIconSelectorTwo",
+                            "component": "IconSelector",
+                            "componentAttributes": {
+                                "canClear": true
+                            }
                         },
                         {
                             "name": "members",
                             "component": "UserSelector",
                             "componentAttributes": {
                                 "isMulti": true,
+                                "canClear": true,
                                 "onlyActiveUsers": true,
                                 "source": {
                                     "service": "service",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2291

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá agregar la property canClear en los siguientes componentes:
- IconSelector
- UserSelector
- SelectMultiLevel => en este caso solo deberá considerar esta prop en el primer nivel

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó la prop canClear a los selector definidos en la descripcion

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README