### PR TITLE
remove canExport canEdit prop default values

### DIFF
--- a/lib/schemas/common/browseBase/browseBase.js
+++ b/lib/schemas/common/browseBase/browseBase.js
@@ -29,10 +29,10 @@ const getBrowseBaseSchema = (isPage = false) => {
 		staticFilters: getEndpointParameters(isPage),
 		endpointParameters: getEndpointParameters(isPage),
 		canPreview: { type: 'boolean', default: false },
-		canEdit: { type: 'boolean', default: true },
 		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },
-		canExport: { type: 'boolean', default: true },
+		canEdit: { type: 'boolean' },
+		canExport: { type: 'boolean' },
 		canRefresh: { type: 'boolean' },
 		statusBar: {
 			type: 'object',

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1104,6 +1104,7 @@ sections:
   rootComponent: BrowseSection
   sourceField: fieldName
   canRefresh: true
+  canEdit: false
 
   themes:
     themeOne:

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -2007,7 +2007,6 @@
         }
     ],
     "canPreview": false,
-    "canEdit": true,
     "canCreate": true,
     "canExport": true,
     "canImport": true,

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1990,9 +1990,8 @@
                 }
             ],
             "canPreview": false,
-            "canEdit": true,
+            "canEdit": false,
             "canCreate": true,
-            "canExport": true,
             "canView": false,
             "pageSize": 60
         },
@@ -2336,9 +2335,7 @@
                 }
             ],
             "canPreview": false,
-            "canEdit": true,
             "canCreate": true,
-            "canExport": true,
             "canView": false,
             "pageSize": 60
         },
@@ -2396,9 +2393,7 @@
                         }
                     ],
                     "canPreview": false,
-                    "canEdit": true,
                     "canCreate": true,
-                    "canExport": true,
                     "canView": false,
                     "pageSize": 60
                 }


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2324

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá eliminar del validador toda configuración agregada automáticamente
Se deberá pasar al front dichas configuraciones
Se deberá modificar las siguientes configuraciones:
Settear por default canEdit: true
Settear por default canExport: true

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se removieron del schema de browse los valores por default las props de canEdit y canExport

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README