### PR TITLE
add new propertys for schema

### DIFF
--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -13,6 +13,7 @@ module.exports = makeComponent({
 		canCreate: { type: 'boolean' },
 		icon: { type: 'string' },
 		preloadOptions: { type: 'boolean' },
+		responseProperty: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/common-sections/sections/components/fieldGroup.js
+++ b/lib/schemas/common-sections/sections/components/fieldGroup.js
@@ -9,6 +9,7 @@ module.exports = {
 		properties: {
 			name: { type: 'string' },
 			icon: { type: 'string' },
+			translateLabel: { type: 'boolean' },
 			position: {
 				type: 'string',
 				enum: ['left', 'right']

--- a/lib/schemas/common-sections/sections/formSection.js
+++ b/lib/schemas/common-sections/sections/formSection.js
@@ -14,6 +14,7 @@ module.exports = {
 			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: formSection },
+			columnsType: { type: 'string', enum: ['default', 'even'] },
 			sourceField: { type: 'string' },
 			dependencies: { $ref: 'schemaDefinitions#/definitions/dependencies' },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/lib/schemas/common-sections/sections/mainForm.js
+++ b/lib/schemas/common-sections/sections/mainForm.js
@@ -14,6 +14,7 @@ module.exports = {
 			title: { type: 'string' },
 			name: { type: 'string', const: 'mainFormSection' },
 			rootComponent: { type: 'string', const: mainForm },
+			columnsType: { type: 'string', enum: ['default', 'even'] },
 			dependencies: { $ref: 'schemaDefinitions#/definitions/dependencies' },
 			fieldsGroup,
 			hideUserCreated: { type: 'boolean' },

--- a/lib/schemas/common-sections/sections/readOnlySection.js
+++ b/lib/schemas/common-sections/sections/readOnlySection.js
@@ -14,6 +14,7 @@ module.exports = {
 			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: readOnlySection },
+			columnsType: { type: 'string', enum: ['default', 'even'] },
 			dependencies: { $ref: 'schemaDefinitions#/definitions/dependencies' },
 			fieldsGroup,
 			hideUserCreated: { type: 'boolean' },

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -16,6 +16,7 @@ module.exports = makeComponent({
 		icon: { type: 'string' },
 		preloadOptions: { type: 'boolean' },
 		canCreate: { type: 'boolean' },
+		responseProperty: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -447,6 +447,7 @@
             "component": "Select",
             "componentAttributes": {
                 "translateLabels": true,
+                "responseProperty": "someField",
                 "options": {
                     "scope": "remote",
                     "endpoint": {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -81,6 +81,7 @@ sections:
   - name: mainFormSection
     rootComponent: MainForm
     icon: catalogue
+    columnsType: default
     hideUserModified: false
     hideUserCreated: true
     dependencies:
@@ -872,6 +873,7 @@ sections:
           component: Select
           componentAttributes:
             translateLabels: true
+            responseProperty: someField
             options:
               scope: remote
               endpoint:
@@ -1389,6 +1391,7 @@ sections:
   - name: testFormSection
     rootComponent: FormSection
     sourceField: fieldName
+    columnsType: even
     hideUserModified: false
     hideUserCreated: true
     themes:

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -431,6 +431,7 @@
             "component": "Select",
             "componentAttributes": {
                 "translateLabels": true,
+                "responseProperty": "someField",
                 "options": {
                     "scope": "remote",
                     "searchParam": "filters[search]",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -125,6 +125,7 @@
         {
             "name": "mainFormSection",
             "rootComponent": "MainForm",
+            "columnsType": "default",
             "icon": "catalogue",
             "hideUserModified": false,
             "hideUserCreated": true,
@@ -1367,6 +1368,7 @@
                             "component": "Select",
                             "componentAttributes": {
                                 "translateLabels": true,
+                                "responseProperty": "someField",
                                 "options": {
                                     "scope": "remote",
                                     "searchParam": "filters[search]",
@@ -2200,6 +2202,7 @@
             "name": "testFormSection",
             "rootComponent": "FormSection",
             "sourceField": "fieldName",
+            "columnsType": "even",
             "hideUserModified": false,
             "hideUserCreated": true,
             "themes": {

--- a/tests/mocks/schemas/expected/preview.json
+++ b/tests/mocks/schemas/expected/preview.json
@@ -150,6 +150,7 @@
             "name": "mainFormSection",
             "icon": "catalogue",
             "rootComponent": "ReadOnlySection",
+            "columnsType": "even",
             "fieldsGroup": [
                 {
                     "name": "detail",
@@ -247,6 +248,7 @@
                 {
                     "name": "others",
                     "position": "right",
+                    "translateLabel": false,
                     "fields": [
                         {
                             "name": "text",

--- a/tests/mocks/schemas/preview.yml
+++ b/tests/mocks/schemas/preview.yml
@@ -100,6 +100,7 @@ sections:
 - name: mainFormSection
   icon: catalogue
   rootComponent: ReadOnlySection
+  columnsType: even
   fieldsGroup:
   - name: detail
     icon: catalogue
@@ -162,6 +163,7 @@ sections:
 
   - name: others
     position: right
+    translateLabel: false
     fields:
     - name: text
       component: Text


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deben agregar las siguientes properties:

En los schemas de `MainForm`, `ReadOnlySection` y los `FormSections`
agregar las siguiente prop
- columnsType: [ default , even ]

A los selects remotos de forms y filtros agregar las siguiente property en los componentAttributes
- responseProperty(string)

A los fieldGroups se le agrego la siguiente property
- translateLabel(boolean)

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las siguientes properties a

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README