### PR TITLE
JMV-2453 schema prefix validation

### DIFF
--- a/lib/schemas/browse/modules/components/link.js
+++ b/lib/schemas/browse/modules/components/link.js
@@ -8,7 +8,7 @@ module.exports = makeComponent({
 	name: link,
 	properties: {
 		translateLabels: { type: 'boolean' },
-		label: { type: 'string' },
+		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelField: { type: 'string' },
 		labelMapper: mapper,
 		target: { type: 'string' },

--- a/lib/schemas/browse/modules/field.js
+++ b/lib/schemas/browse/modules/field.js
@@ -13,7 +13,7 @@ module.exports = {
 	properties: {
 		component: { type: 'string', enum: Object.values(componentNames) },
 		name: { type: 'string' },
-		label: { type: 'string' },
+		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		noLabel: { type: 'boolean' },
 		translateLabel: { type: 'boolean' },
 		dependency: { type: 'string' },

--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -6,7 +6,7 @@ module.exports = makeComponent({
 	name: 'Select',
 	properties: {
 		translateLabels: { type: 'boolean', default: true },
-		labelPrefix: { type: 'string' },
+		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		canClear: { type: 'boolean' },
 		options: {
 			oneOf: [
@@ -15,7 +15,7 @@ module.exports = makeComponent({
 					items: {
 						type: 'object',
 						properties: {
-							label: { type: 'string' },
+							label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 							value: {
 								anyOf: [
 									{ type: 'number' },

--- a/lib/schemas/browse/modules/filters/components/select-options/localOptions.js
+++ b/lib/schemas/browse/modules/filters/components/select-options/localOptions.js
@@ -31,7 +31,7 @@ module.exports = {
 										{ type: 'number' }
 									]
 								},
-								label: { type: 'string' }
+								label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' }
 							},
 							required: ['value', 'label'],
 							additionalProperties: false

--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -8,7 +8,7 @@ module.exports = makeComponent({
 	name: [select, multiselect],
 	properties: {
 		translateLabels: { type: 'boolean' },
-		labelPrefix: { type: 'string' },
+		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		canClear: { type: 'boolean' },
 		canCreate: { type: 'boolean' },
 		icon: { type: 'string' },

--- a/lib/schemas/browse/modules/filters/filters.js
+++ b/lib/schemas/browse/modules/filters/filters.js
@@ -9,7 +9,7 @@ module.exports = {
 		type: 'object',
 		properties: {
 			name: { type: 'string' },
-			label: { type: 'string' },
+			label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 			component: { type: 'string', enum: Object.values(componentNames) },
 			componentAttributes: {
 				type: 'object',

--- a/lib/schemas/browse/modules/interactions.js
+++ b/lib/schemas/browse/modules/interactions.js
@@ -12,7 +12,7 @@ const interactionComponents = [
 		then: {
 			properties: {
 				type: { const: 'Tooltip' },
-				label: { type: 'string' },
+				label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 				translateLabels: { type: 'boolean' },
 				mapper
 			},
@@ -32,7 +32,7 @@ const interactionComponents = [
 				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 				endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 				translateLabels: { type: 'boolean' },
-				title: { type: 'string' },
+				title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 				listFields: {
 					type: 'array',
 					items: { type: 'string' },

--- a/lib/schemas/common-sections/sections/apiKeysSection.js
+++ b/lib/schemas/common-sections/sections/apiKeysSection.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: apiKeysSection },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/lib/schemas/common-sections/sections/browseSection.js
+++ b/lib/schemas/common-sections/sections/browseSection.js
@@ -12,7 +12,6 @@ module.exports = {
 	then: {
 		properties: {
 			...getBrowseBaseSchema(),
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: browseSection },
 			sourceField: { type: 'string' }

--- a/lib/schemas/common-sections/sections/comments.js
+++ b/lib/schemas/common-sections/sections/comments.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: comments }
 		},

--- a/lib/schemas/common-sections/sections/commonProperties.js
+++ b/lib/schemas/common-sections/sections/commonProperties.js
@@ -6,6 +6,7 @@ const themes = require('../../common/themes');
 
 module.exports = {
 	topComponents: makeTopComponents(),
+	title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 	includeDataFrom: {
 		type: 'array',
 		items: { type: 'string' },

--- a/lib/schemas/common-sections/sections/formSection.js
+++ b/lib/schemas/common-sections/sections/formSection.js
@@ -11,7 +11,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: formSection },
 			columnsType: { type: 'string', enum: ['default', 'even'] },

--- a/lib/schemas/common-sections/sections/logsBrowseSection.js
+++ b/lib/schemas/common-sections/sections/logsBrowseSection.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: logsBrowseSection }
 		},

--- a/lib/schemas/common-sections/sections/mainForm.js
+++ b/lib/schemas/common-sections/sections/mainForm.js
@@ -11,7 +11,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string', const: 'mainFormSection' },
 			rootComponent: { type: 'string', const: mainForm },
 			columnsType: { type: 'string', enum: ['default', 'even'] },

--- a/lib/schemas/common-sections/sections/multiSection.js
+++ b/lib/schemas/common-sections/sections/multiSection.js
@@ -19,7 +19,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: multiSection },
 			defaultSection: { type: 'string' },

--- a/lib/schemas/common-sections/sections/omsControls.js
+++ b/lib/schemas/common-sections/sections/omsControls.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: omsControls }
 		},

--- a/lib/schemas/common-sections/sections/omsOrderHistory.js
+++ b/lib/schemas/common-sections/sections/omsOrderHistory.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: omsOrderHistory },
 			milestones: {

--- a/lib/schemas/common-sections/sections/omsOrderInfo.js
+++ b/lib/schemas/common-sections/sections/omsOrderInfo.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: omsOrderInfo }
 		},

--- a/lib/schemas/common-sections/sections/orderItemsSection.js
+++ b/lib/schemas/common-sections/sections/orderItemsSection.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: orderItemsSection },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/lib/schemas/common-sections/sections/readOnlySection.js
+++ b/lib/schemas/common-sections/sections/readOnlySection.js
@@ -11,7 +11,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: readOnlySection },
 			columnsType: { type: 'string', enum: ['default', 'even'] },

--- a/lib/schemas/common-sections/sections/remoteSection.js
+++ b/lib/schemas/common-sections/sections/remoteSection.js
@@ -10,7 +10,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: remoteSection },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/lib/schemas/common-sections/sections/section-files/common.js
+++ b/lib/schemas/common-sections/sections/section-files/common.js
@@ -10,7 +10,6 @@ module.exports = (sectionName, properties = {}) => ({
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			fileUploadEndpoint: endpoint,
 			fileRelationEndpoint: endpoint,

--- a/lib/schemas/common-sections/sections/summary/commonCardsProps.js
+++ b/lib/schemas/common-sections/sections/summary/commonCardsProps.js
@@ -12,7 +12,7 @@ module.exports = {
 			]
 		},
 		name: { type: 'string' },
-		title: { type: 'string' },
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		hideTitle: { type: 'boolean' }
 	},
 	requiredProperties: ['name', 'x', 'y', 'width', 'height']

--- a/lib/schemas/common-sections/sections/summary/summary.js
+++ b/lib/schemas/common-sections/sections/summary/summary.js
@@ -16,7 +16,6 @@ module.exports = {
 	},
 	then: {
 		properties: {
-			title: { type: 'string' },
 			name: { type: 'string' },
 			rootComponent: { type: 'string', const: summary },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },

--- a/lib/schemas/common/actions/action.js
+++ b/lib/schemas/common/actions/action.js
@@ -14,7 +14,7 @@ const endpointParameters = {
 module.exports = {
 	type: 'object',
 	properties: {
-		title: { type: 'string' },
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		name: { type: 'string' },
 		color: { type: 'string' },
 		icon: { type: 'string' },

--- a/lib/schemas/common/base.js
+++ b/lib/schemas/common/base.js
@@ -5,7 +5,7 @@ module.exports = {
 		root: { type: 'string' },
 		service: { type: 'string' },
 		name: { type: 'string' },
-		title: { type: 'string' }
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' }
 	},
 	required: ['root', 'name', 'service']
 };

--- a/lib/schemas/common/browseBase/massiveActions.js
+++ b/lib/schemas/common/browseBase/massiveActions.js
@@ -5,7 +5,7 @@ const getEndpointParameters = require('../endpointParameters');
 module.exports = isPage => ({
 	type: 'object',
 	properties: {
-		title: { type: 'string' },
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		translateTitle: { type: 'boolean' },
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		endpointParameters: getEndpointParameters(isPage)

--- a/lib/schemas/common/graphs.js
+++ b/lib/schemas/common/graphs.js
@@ -10,7 +10,7 @@ const graphMappingCommonProps = {
 		title: {
 			type: 'object',
 			properties: {
-				value: { type: 'string' },
+				value: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 				mapper
 			},
 			required: ['value'],
@@ -38,9 +38,9 @@ module.exports = {
 			filters,
 			component: { type: 'string' },
 			name: { type: 'string' },
-			title: { type: 'string' },
+			title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 			translateTitle: { type: 'boolean' },
-			subtitle: { type: 'string' },
+			subtitle: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 			translateSubtitle: { type: 'boolean' },
 			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 			endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },

--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -68,7 +68,7 @@ const baseMapperSchema = [
 					properties: {
 						addWhitespace: { type: 'boolean' },
 						translate: { type: 'boolean' },
-						value: { type: 'string' }
+						value: { $ref: 'schemaDefinitions#/definitions/stringPrefix' }
 					},
 					additionalProperties: false
 				}

--- a/lib/schemas/common/stringPrefix.js
+++ b/lib/schemas/common/stringPrefix.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// prefix with common and views '^(?:(?!common\\.|views\\.).)*$'
+
+module.exports = {
+	type: 'string',
+	pattern: '^(?:(?!views\\.).)*$'
+};

--- a/lib/schemas/common/topComponents.js
+++ b/lib/schemas/common/topComponents.js
@@ -71,7 +71,7 @@ const makeTopComponents = (isBrowsePage = false) => ({
 					properties: {
 						component: { const: specialTopComponents.actionForm },
 						name: { type: 'string' },
-						title: { type: 'string' },
+						title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 						icon: { type: 'string' },
 						iconColor: { type: 'string' },
 						color: { type: 'string' },

--- a/lib/schemas/definitions/index.js
+++ b/lib/schemas/definitions/index.js
@@ -5,6 +5,7 @@ const editNewField = require('../edit-new/modules/field');
 const endpoint = require('../common/endpoint');
 const getEndpointParameters = require('../common/endpointParameters');
 const dependencies = require('../common/dependencies');
+const stringPrefix = require('../common/stringPrefix');
 const graphs = require('../common/graphs');
 
 module.exports = {
@@ -14,6 +15,7 @@ module.exports = {
 		editNewField,
 		endpoint,
 		dependencies,
+		stringPrefix,
 		graphs,
 		endpointParameters: getEndpointParameters()
 	}

--- a/lib/schemas/edit-new/modules/components/multiInput.js
+++ b/lib/schemas/edit-new/modules/components/multiInput.js
@@ -14,8 +14,8 @@ module.exports = makeComponent({
 	name: multiInput,
 	properties: {
 		...commonProps,
-		labelsPrefix: { type: 'string', default: '' },
-		labelPrefix: { type: 'string', default: '' },
+		labelsPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
+		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		translateLabels: { type: 'boolean', default: true },
 		requiredFields: {
 			type: 'array',

--- a/lib/schemas/edit-new/modules/components/selectForm.js
+++ b/lib/schemas/edit-new/modules/components/selectForm.js
@@ -17,7 +17,7 @@ module.exports = makeComponent({
 	name: selectForm,
 	properties: {
 		translateLabels: { type: 'boolean' },
-		labelPrefix: { type: 'string' },
+		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },
 		icon: { type: 'string' },

--- a/lib/schemas/edit-new/modules/components/selectMultilevel.js
+++ b/lib/schemas/edit-new/modules/components/selectMultilevel.js
@@ -12,7 +12,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		maxLevel: { type: 'number' },
 		parentFilterName: { type: 'string' },
-		labelPrefix: { type: 'string' },
+		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },
 		options: {

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -10,7 +10,7 @@ module.exports = makeComponent({
 	name: [select, multiselect],
 	properties: {
 		translateLabels: { type: 'boolean' },
-		labelPrefix: { type: 'string' },
+		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },
 		icon: { type: 'string' },

--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -13,7 +13,7 @@ module.exports = {
 	properties: {
 		component: { enum: Object.values(componentNames) },
 		name: { type: 'string' },
-		label: { type: 'string' },
+		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		placeholder: { type: 'string' },
 		noLabel: { type: 'boolean' },
 		translateLabel: { type: 'boolean' },

--- a/lib/schemas/edit-new/modules/options/localOptions.js
+++ b/lib/schemas/edit-new/modules/options/localOptions.js
@@ -31,7 +31,7 @@ module.exports = {
 										{ type: 'number' }
 									]
 								},
-								label: { type: 'string' }
+								label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' }
 							},
 							required: ['value', 'label'],
 							additionalProperties: false

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -12,7 +12,7 @@ module.exports = {
 		remoteActions: {
 			type: 'object',
 			properties: {
-				title: { type: 'string' },
+				title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 				translateTitle: { type: 'boolean' },
 				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 				sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }

--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -13,7 +13,7 @@ const cardNames = require('./cards/cardNames');
 const cardsModified = cards.map(card => modifySchemaThenProperties(card, {
 	properties: {
 		name: { type: 'string' },
-		label: { type: 'string' },
+		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		translateLabel: { type: 'boolean' },
 		conditions: makeConditions(false, true)
 	},

--- a/lib/schemas/preview/actions/action.js
+++ b/lib/schemas/preview/actions/action.js
@@ -11,7 +11,7 @@ const commonAttrs = {
 module.exports = {
 	type: 'object',
 	properties: {
-		title: { type: 'string' },
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		name: { type: 'string' },
 		type: { type: 'string' },
 		componentAttributes: commonAttrs,


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2453

**DESCRIPCIÓN DEL REQUERIMIENTO**

Para todos los casos en donde se acepte un key de traducción (labelPrefix, mapper prefix, label) se deberá validar y prohibir el uso de los siguientes namespace’s (validador):
- views
- common

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se cambiaron los schemas de muchos schemas de pagina y componentes que tenian, label, title, labelPrefix y mapper de prefix por un schema de string validando que no tnegan los namespaces de views y common.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README