### PR TITLE
JMV-2463 add schema action monitor cards

### DIFF
--- a/lib/schemas/common/actionCallbacks.js
+++ b/lib/schemas/common/actionCallbacks.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Edit page section topComponents callbacks
-const sectionCallbacks = ['reloadSectionData'];
+const sectionCallbacks = ['reloadData', 'reloadSectionData'];
 // Browse page topComponents callbacks
 const pageBrowseCallbacks = ['reloadBrowse'];
 

--- a/lib/schemas/monitor/cards/BaseCard.js
+++ b/lib/schemas/monitor/cards/BaseCard.js
@@ -2,6 +2,7 @@
 
 const { baseCard } = require('./cardNames');
 const fieldsGroup = require('../../../schemas/common-sections/sections/components/fieldGroup');
+const actions = require('./actions');
 
 module.exports = {
 	if: {
@@ -12,6 +13,7 @@ module.exports = {
 	then: {
 		properties: {
 			component: { type: 'string', const: baseCard },
+			actions,
 			fieldsGroup
 		},
 		required: ['component', 'fieldsGroup'],

--- a/lib/schemas/monitor/cards/actions.js
+++ b/lib/schemas/monitor/cards/actions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const makeActionCallbacks = require('../../common/actionCallbacks');
+const makeConditions = require('../../common/conditions');
 
 const customCallbacks = ['reloadMonitorData'];
 
@@ -20,6 +21,7 @@ module.exports = {
 				items: { $ref: 'schemaDefinitions#/definitions/editNewField' },
 				minItems: 1
 			},
+			conditions: makeConditions(false, false),
 			callback: makeActionCallbacks({ customCallbacks })
 		},
 		additionalProperties: false,

--- a/lib/schemas/monitor/cards/actions.js
+++ b/lib/schemas/monitor/cards/actions.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const makeActionCallbacks = require('../../common/actionCallbacks');
+
+const customCallbacks = ['reloadMonitorData'];
+
+module.exports = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			name: { type: 'string' },
+			icon: { type: 'string' },
+			path: { type: 'string' },
+			target: { type: 'string' },
+			endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+			endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
+			schema: {
+				type: 'array',
+				items: { $ref: 'schemaDefinitions#/definitions/editNewField' },
+				minItems: 1
+			},
+			callback: makeActionCallbacks({ customCallbacks })
+		},
+		additionalProperties: false,
+		required: ['name']
+	},
+	minItems: 1
+};

--- a/lib/schemas/monitor/cards/actions.js
+++ b/lib/schemas/monitor/cards/actions.js
@@ -3,7 +3,7 @@
 const makeActionCallbacks = require('../../common/actionCallbacks');
 const makeConditions = require('../../common/conditions');
 
-const customCallbacks = ['reloadMonitorData'];
+const customCallbacks = ['reloadData'];
 
 module.exports = {
 	type: 'array',

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -201,6 +201,17 @@
                     "name": "testLink",
                     "path": "/test/{id}",
                     "target": "_self",
+                    "conditions": {
+                        "showWhen": [
+                            [
+                                {
+                                    "name": "isEqualTo",
+                                    "field": "name",
+                                    "referenceValue": "test"
+                                }
+                            ]
+                        ]
+                    },
                     "endpointParameters": [
                         {
                             "name": "id",

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -230,7 +230,7 @@
                         "method": "methodName",
                         "resolve": false
                     },
-                    "callback": "reloadMonitorData",
+                    "callback": "reloadData",
                     "schema": [
                         {
                             "name": "fieldNameOne",

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -177,6 +177,63 @@
             "component": "BaseCard",
             "label": "some.label.key",
             "translateLabel": false,
+            "actions": [
+                {
+                    "name": "testEndpoint",
+                    "callback": "refresh",
+                    "endpoint": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "endpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "dynamic": "id"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "testLink",
+                    "path": "/test/{id}",
+                    "target": "_self",
+                    "endpointParameters": [
+                        {
+                            "name": "id",
+                            "target": "path",
+                            "value": {
+                                "dynamic": "id"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "testForm",
+                    "endpoint": {
+                        "service": "serviceName",
+                        "namespace": "namespaceName",
+                        "method": "methodName",
+                        "resolve": false
+                    },
+                    "callback": "reloadMonitorData",
+                    "schema": [
+                        {
+                            "name": "fieldNameOne",
+                            "component": "Input",
+                            "componentAttributes": {}
+                        },
+                        {
+                            "name": "fieldNameTwo",
+                            "component": "Switch",
+                            "componentAttributes": {}
+                        }
+                    ]
+                }
+            ],
             "fieldsGroup": [
                 {
                     "name": "info",

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -154,7 +154,7 @@ fields:
           namespace: namespaceName
           method: methodName
           resolve: false
-        callback: reloadMonitorData
+        callback: reloadData
         schema:
           - name: fieldNameOne
             component: Input

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -120,6 +120,43 @@ fields:
     component: BaseCard
     label: some.label.key
     translateLabel: false
+    actions:
+      - name: testEndpoint
+        callback: refresh
+        endpoint:
+          service: serviceName
+          namespace: namespaceName
+          method: methodName
+          resolve: false
+        endpointParameters:
+          - name: id
+            target: path
+            value:
+              dynamic: id
+
+      - name: testLink
+        path: /test/{id}
+        target: _self
+        endpointParameters:
+          - name: id
+            target: path
+            value:
+              dynamic: id
+
+      - name: testForm
+        endpoint:
+          service: serviceName
+          namespace: namespaceName
+          method: methodName
+          resolve: false
+        callback: reloadMonitorData
+        schema:
+          - name: fieldNameOne
+            component: Input
+
+          - name: fieldNameTwo
+            component: Switch
+
     fieldsGroup:
       - name: info
         fields:

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -137,6 +137,11 @@ fields:
       - name: testLink
         path: /test/{id}
         target: _self
+        conditions:
+          showWhen:
+            - - name: isEqualTo
+                field: name
+                referenceValue: test
         endpointParameters:
           - name: id
             target: path


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2463

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se debe agregar el schema para las acciones de las cards de monitor agregandole condicionales.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó el schema simil remoteActions al schema de cards de monitor, agregandole condicionales a las actions.


**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README