### PR TITLE
change autoRefresh monitor property

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -31,7 +31,7 @@ module.exports = {
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 		dependencies: { $ref: 'schemaDefinitions#/definitions/dependencies' },
-		autoRefresh: { type: 'boolean' },
+		autoRefresh: { type: 'number', minimum: 60 },
 		themes,
 		schemaSource: {
 			type: 'object',

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -2,7 +2,7 @@
     "service": "picking",
     "name": "views-demo-monitor",
     "root": "Monitor",
-    "autoRefresh": true,
+    "autoRefresh": 60,
     "source": {
         "service": "playground",
         "namespace": "views-demo",

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -2,7 +2,7 @@ service: picking
 name: views-demo-monitor
 root: Monitor
 
-autoRefresh: true
+autoRefresh: 60
 
 source:
   service: playground


### PR DESCRIPTION
**LINK AL TICKET**

**https://fizzmod.atlassian.net/browse/JMV-2469**

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá poder pasarle una property al monitor para poder definir el tiempo del autoRefresh
Se deberá aceptar un valor numérico
Dicho valor deberá representar segundos
Se deberá tomar como valor minimo 60 segundos

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se cambió el schema de autoRefresh de monitor de boolean a number con el minimo de 60

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README