### PR TITLE
move canImport in browse base schema

### DIFF
--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -3,7 +3,6 @@
 const { properties, required } = require('../common/base');
 const actions = require('../common/actions');
 const getBrowseBaseSchema = require('../common/browseBase');
-const makeExportImportSchema = require('../common/browseBase/import-export');
 const makeTopComponents = require('../common/topComponents');
 
 module.exports = {
@@ -11,7 +10,6 @@ module.exports = {
 	properties: {
 		...properties,
 		...getBrowseBaseSchema(true),
-		canImport: makeExportImportSchema(false),
 		topComponents: makeTopComponents(true),
 		root: { const: 'Browse' },
 		actions

--- a/lib/schemas/common/browseBase/browseBase.js
+++ b/lib/schemas/common/browseBase/browseBase.js
@@ -30,6 +30,7 @@ const getBrowseBaseSchema = (isPage = false) => {
 		staticFilters: getEndpointParameters(isPage),
 		endpointParameters: getEndpointParameters(isPage),
 		canExport: makeExportImportSchema(),
+		canImport: makeExportImportSchema(false),
 		canPreview: { type: 'boolean', default: false },
 		canCreate: { type: 'boolean', default: true },
 		canView: { type: 'boolean', default: false },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1097,6 +1097,8 @@ sections:
     sourceField: fieldName
     canRefresh: true
     canEdit: false
+    canImport: true
+    canExport: true
     themes:
       themeOne:
         new: black

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1684,6 +1684,8 @@
             "rootComponent": "BrowseSection",
             "sourceField": "fieldName",
             "canRefresh": true,
+            "canImport": true,
+            "canExport": true,
             "themes": {
                 "themeOne": {
                     "new": "black",


### PR DESCRIPTION
**LINK AL TICKET**

**https://fizzmod.atlassian.net/browse/JMV-2492**

**DESCRIPCIÓN DEL REQUERIMIENTO**

La property canExport y canImport deben estar en los browseSection.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se cambió el schema de browseBase para que tenga tanto canExport como canImport, para que lo tengan todos los browseSection

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README