### PR TITLE
changes in stringPrefix regex

### DIFF
--- a/lib/schemas/common/stringPrefix.js
+++ b/lib/schemas/common/stringPrefix.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// prefix with common and views '^(?:(?!common\\.|views\\.).)*$'
-
 module.exports = {
 	type: 'string',
-	pattern: '^(?:(?!views\\.).)*$'
+	pattern: '^(?:(?!views\\.([a-zA-Z0-9]*\\.){2,}).)*$'
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -60,7 +60,7 @@ themes:
       somePropTwo: someValue
 collapseSections: true
 remoteActions:
-  title: some.title
+  title: views.title.someTitle
   translateTitle: true
   source:
     service: serviceName

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -95,7 +95,7 @@
     },
     "collapseSections": true,
     "remoteActions": {
-        "title": "some.title",
+        "title": "views.title.someTitle",
         "translateTitle": true,
         "source": {
             "service": "serviceName",


### PR DESCRIPTION
**LINK AL TICKET**

**https://fizzmod.atlassian.net/browse/JMV-2503**

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá modificar el validador para poder usar un prefix que comience con views.
Se deberá validar y restringir que solo se pueda crear hasta un maximo de 2 niveles
Ya que el 3ro va hacer el del propio field

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se cambiò el regex del schema de stringPrefix para que pueda tener prefijos y key traducciones hasta 2 niveles

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README