### PR TITLE
massive actions remove prop required

### DIFF
--- a/lib/schemas/common/browseBase/massiveActions.js
+++ b/lib/schemas/common/browseBase/massiveActions.js
@@ -14,7 +14,6 @@ module.exports = isPage => ({
 		endpointParameters: getEndpointParameters(isPage),
 		actions: makeGenericActions({ customCallbacks })
 	},
-	required: ['source'],
 	additionalProperties: false,
 	minProps: 1
 });


### PR DESCRIPTION
DESCRIPCIÓN DEL REQUERIMIENTO

Se tiene que sacar el required de la prop source, de massiveActions.
