### PR TITLE
Jmv 2568 map location new props

### DIFF
--- a/lib/schemas/edit-new/modules/components/location.js
+++ b/lib/schemas/edit-new/modules/components/location.js
@@ -2,6 +2,7 @@
 
 const { makeComponent } = require('../../../utils');
 const { location } = require('../componentNames');
+const { markersSchema } = require('./map');
 
 module.exports = makeComponent({
 	name: location,
@@ -24,6 +25,7 @@ module.exports = makeComponent({
 				}
 			]
 		},
+		markers: markersSchema,
 		fieldsMapping: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/edit-new/modules/components/map.js
+++ b/lib/schemas/edit-new/modules/components/map.js
@@ -29,6 +29,7 @@ const markersSchema = {
 	properties: {
 		icon: { type: 'string' },
 		color: { type: 'string' },
+		size: { type: 'number' },
 		useTheme: { type: ['boolean', 'string'] },
 		themeConditionals,
 		infoSchema: {

--- a/lib/schemas/edit-new/modules/components/map.js
+++ b/lib/schemas/edit-new/modules/components/map.js
@@ -29,7 +29,7 @@ const markersSchema = {
 	properties: {
 		icon: { type: 'string' },
 		color: { type: 'string' },
-		useTheme: { type: 'string' },
+		useTheme: { type: ['boolean', 'string'] },
 		themeConditionals,
 		infoSchema: {
 			type: 'object',

--- a/lib/schemas/edit-new/modules/components/map.js
+++ b/lib/schemas/edit-new/modules/components/map.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { makeComponent } = require('../../../utils');
+const { conditionsSchema } = require('../../../common/conditions/conditions');
+const fieldsGroup = require('../../../common-sections/sections/components/fieldGroup');
 const { map } = require('../componentNames');
 
 const keys = [
@@ -16,12 +18,39 @@ const keys = [
 	'formattedAddress'
 ];
 
+const themeConditionals = {
+	type: 'object',
+	additionalProperties: conditionsSchema,
+	minProperties: 1
+};
+
+const markersSchema = {
+	type: 'object',
+	properties: {
+		icon: { type: 'string' },
+		color: { type: 'string' },
+		useTheme: { type: 'string' },
+		themeConditionals,
+		infoSchema: {
+			type: 'object',
+			properties: {
+				fieldsGroup
+			},
+			minProperties: 1,
+			additionalProperties: false
+		}
+	},
+	additionalProperties: false,
+	minProperties: 1
+};
+
 module.exports = makeComponent({
 	name: map,
 	properties: {
 		showSearchBar: { type: 'boolean' },
 		canAddMarkers: { type: 'boolean' },
 		maxMarkersQuantity: { type: 'number' },
+		markers: markersSchema,
 		fieldsMapping: {
 			type: 'object',
 			properties: keys.reduce((accum, key) => ({
@@ -32,3 +61,5 @@ module.exports = makeComponent({
 		}
 	}
 });
+
+module.exports.markersSchema = markersSchema;

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -581,6 +581,31 @@ sections:
       - name: exampleMap
         component: Map
         componentAttributes:
+          markers:
+            icon: iconName
+            color: colorName
+            useTheme: themeName
+            infoSchema:
+              fieldsGroup:
+                - name: detail
+                  fields:
+                    - name: someField
+                      component: Text
+            themeConditionals:
+              warning:
+                - - name: lowerThan
+                    field: quantity
+                    referenceValue: 10
+                  - name: lowerOrEqualThan
+                    field: quantity
+                    referenceValue: 10
+              error:
+                - - name: greaterThan
+                    field: quantity
+                    referenceValue: 10
+                  - name: greaterOrEqualThan
+                    field: quantity
+                    referenceValue: 10
           fieldsMapping:
             latitude: lat
             longitude: lng
@@ -604,6 +629,31 @@ sections:
         component: Location
         componentAttributes:
           label: some.traduction.label
+          markers:
+            icon: iconName
+            color: colorName
+            useTheme: themeName
+            infoSchema:
+              fieldsGroup:
+                - name: detail
+                  fields:
+                    - name: someField
+                      component: Text
+            themeConditionals:
+              warning:
+                - - name: lowerThan
+                    field: quantity
+                    referenceValue: 10
+                  - name: lowerOrEqualThan
+                    field: quantity
+                    referenceValue: 10
+              error:
+                - - name: greaterThan
+                    field: quantity
+                    referenceValue: 10
+                  - name: greaterOrEqualThan
+                    field: quantity
+                    referenceValue: 10
           fieldsMapping:
             latitude: lat
             longitude: lng

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -584,6 +584,7 @@ sections:
           markers:
             icon: iconName
             color: colorName
+            size: 30
             useTheme: themeName
             infoSchema:
               fieldsGroup:

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -935,6 +935,7 @@
                                 "markers": {
                                     "icon": "iconName",
                                     "color": "colorName",
+                                    "size": 30,
                                     "useTheme": "themeName",
                                     "infoSchema": {
                                         "fieldsGroup": [

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -932,6 +932,55 @@
                             "name": "exampleMap",
                             "component": "Map",
                             "componentAttributes": {
+                                "markers": {
+                                    "icon": "iconName",
+                                    "color": "colorName",
+                                    "useTheme": "themeName",
+                                    "infoSchema": {
+                                        "fieldsGroup": [
+                                            {
+                                                "name": "detail",
+                                                "fields": [
+                                                    {
+                                                        "name": "someField",
+                                                        "component": "Text",
+                                                        "componentAttributes": {}
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "themeConditionals": {
+                                        "warning": [
+                                            [
+                                                {
+                                                    "name": "lowerThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                },
+                                                {
+                                                    "name": "lowerOrEqualThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                }
+                                            ]
+                                        ],
+                                        "error": [
+                                            [
+                                                {
+                                                    "name": "greaterThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                },
+                                                {
+                                                    "name": "greaterOrEqualThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                },
                                 "fieldsMapping": {
                                     "latitude": "lat",
                                     "longitude": "lng",
@@ -963,6 +1012,55 @@
                             "component": "Location",
                             "componentAttributes": {
                                 "label": "some.traduction.label",
+                                "markers": {
+                                    "icon": "iconName",
+                                    "color": "colorName",
+                                    "useTheme": "themeName",
+                                    "infoSchema": {
+                                        "fieldsGroup": [
+                                            {
+                                                "name": "detail",
+                                                "fields": [
+                                                    {
+                                                        "name": "someField",
+                                                        "component": "Text",
+                                                        "componentAttributes": {}
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "themeConditionals": {
+                                        "warning": [
+                                            [
+                                                {
+                                                    "name": "lowerThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                },
+                                                {
+                                                    "name": "lowerOrEqualThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                }
+                                            ]
+                                        ],
+                                        "error": [
+                                            [
+                                                {
+                                                    "name": "greaterThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                },
+                                                {
+                                                    "name": "greaterOrEqualThan",
+                                                    "field": "quantity",
+                                                    "referenceValue": 10
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                },
                                 "fieldsMapping": {
                                     "latitude": "lat",
                                     "longitude": "lng"


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2568

**DESCRIPCIÓN DEL REQUERIMIENTO**

Dentro de componentAttributes se definiran propiedades para customizar el marcador de los mapas
property `markers.icon`
Se deberá poder usar los iconos de la font de janis
En caso de no definirlo, se deberá usar el marker default de janis de la siguiente [forma](https://fizzmod.invisionapp.com/d/main#/console/16040058/440394270/preview)
 property `markers.color` en donde se podrá definir alguno los colores posibles de la font de janis
En caso de no definirlo, se usara el color gris (normal).
propiedades useTheme, themeConditionals  las cuales deben funcionar igual  que el StatusChip
property markerInfo en donde se deberá poder definir las siguientes properties (simil card de monitores):
fieldsGroups
- - fields
- - - conditions

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agregó el schema de markers con las properties descriptas en el requerimiento y se los agregué a los schemas de los componentes de Map y Location.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README