### PR TITLE
JMV-2603 - add new props for fieldsArray and add new prop in field form

### DIFF
--- a/lib/schemas/edit-new/modules/components/fieldsArray.js
+++ b/lib/schemas/edit-new/modules/components/fieldsArray.js
@@ -17,10 +17,17 @@ module.exports = makeComponent({
 		canChangeElements: { type: 'boolean' },
 		minElements: { type: 'number' },
 		maxElements: { type: 'number' },
-		addButtonText: { type: 'string' },
+		addButtonText: {
+			oneOf: [
+				{ const: false },
+				{ type: 'string' }
+			]
+		},
 		addButtonTextColor: { type: 'string' },
 		addButtonBackgroundColor: { type: 'string' },
-		addButtonIcon: { type: 'string' }
+		addButtonPosition: { enum: ['left', 'right'] },
+		addButtonIcon: { type: 'string' },
+		showDivisor: { type: 'boolean' }
 	},
 	requiredProperties: ['fields']
 });

--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -17,6 +17,7 @@ module.exports = {
 		placeholder: { type: 'string' },
 		noLabel: { type: 'boolean' },
 		translateLabel: { type: 'boolean' },
+		floatingLabel: { type: 'boolean' },
 		dependency: { type: 'string' },
 		width: { type: 'number' },
 		position: { type: 'string', enum: ['left', 'right'] },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -797,6 +797,7 @@ sections:
 
       - name: someInput
         component: Input
+        floatingLabel: true
         width: 50
         componentAttributes:
           autoComplete: true
@@ -812,6 +813,9 @@ sections:
         component: FieldsArray
         componentAttributes:
           canChangeElements: true
+          addButtonText: false
+          addButtonPosition: left
+          showDivisor: false
           minElements: 1
           maxElements: 3
           fields:
@@ -832,6 +836,7 @@ sections:
           addButtonTextColor: colorName
           addButtonBackgroundColor: colorName
           addButtonIcon: iconName
+          addButtonPosition: right
           fields:
             - name: test
               component: Text

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1279,6 +1279,7 @@
                         {
                             "name": "someInput",
                             "component": "Input",
+                            "floatingLabel": true,
                             "width": 50,
                             "componentAttributes": {
                                 "autoComplete": true,
@@ -1300,6 +1301,9 @@
                                 "canChangeElements": true,
                                 "minElements": 1,
                                 "maxElements": 3,
+                                "addButtonText": false,
+                                "addButtonPosition": "left",
+                                "showDivisor": false,
                                 "fields": [
                                     {
                                         "name": "test1",
@@ -1327,6 +1331,7 @@
                                 "addButtonTextColor": "colorName",
                                 "addButtonBackgroundColor": "colorName",
                                 "addButtonIcon": "iconName",
+                                "addButtonPosition": "right",
                                 "fields": [
                                     {
                                         "name": "test",


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2603

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá poder definir en los componentes ( **input** / **select**) si usa el el label normal o floating
**floatingLabel**: true (el default es false)
Se deberá poder pasarle una property a para poder eliminar el divisor entre los elementos
La idea es que las opciones se vean más juntas y que se entienda que son parte de los mismo
Se deberá revisar el margin del ultimo input que tiene un width
Se deberá poder setear la propiedad **addButtonText** vacía (false || '') y que no muestre un espacio
Se deberá agregar una property **addButtonPosition** con los valores left / right, en donde left deberá ser el default.
Actualizar la documentación con las nuevas props.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las modificaciones al schema de FieldsArray y se agregó una nueva prop al Field de form.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README