### PR TITLE
add modalSize in diferent components and schema

### DIFF
--- a/lib/schemas/common/browseBase/massiveActions.js
+++ b/lib/schemas/common/browseBase/massiveActions.js
@@ -12,6 +12,7 @@ module.exports = isPage => ({
 		translateTitle: { type: 'boolean' },
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		endpointParameters: getEndpointParameters(isPage),
+		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		actions: makeGenericActions({ customCallbacks })
 	},
 	additionalProperties: false,

--- a/lib/schemas/common/generic-actions/action.js
+++ b/lib/schemas/common/generic-actions/action.js
@@ -79,6 +79,7 @@ module.exports = {
 						type: 'object',
 						properties: {
 							...commonAttrs,
+							modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 							endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 							endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 							fields: {

--- a/lib/schemas/common/modalSize.js
+++ b/lib/schemas/common/modalSize.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+	type: 'string',
+	enum: ['small', 'medium', 'large', 'extra-large', 'mobile']
+};

--- a/lib/schemas/common/topComponents.js
+++ b/lib/schemas/common/topComponents.js
@@ -76,6 +76,7 @@ const makeTopComponents = (isBrowsePage = false) => ({
 						iconColor: { type: 'string' },
 						color: { type: 'string' },
 						backgroundColor: { type: 'string' },
+						modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 						fields: {
 							type: 'array',
 							items: {

--- a/lib/schemas/definitions/index.js
+++ b/lib/schemas/definitions/index.js
@@ -8,6 +8,7 @@ const dependencies = require('../common/dependencies');
 const stringPrefix = require('../common/stringPrefix');
 const autoRefresh = require('../common/autoRefresh');
 const graphs = require('../common/graphs');
+const modalSize = require('../common/modalSize');
 
 module.exports = {
 	$id: 'schemaDefinitions',
@@ -18,6 +19,7 @@ module.exports = {
 		dependencies,
 		stringPrefix,
 		autoRefresh,
+		modalSize,
 		graphs,
 		endpointParameters: getEndpointParameters()
 	}

--- a/lib/schemas/edit-new/modules/components/location.js
+++ b/lib/schemas/edit-new/modules/components/location.js
@@ -26,6 +26,7 @@ module.exports = makeComponent({
 			]
 		},
 		markers: markersSchema,
+		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		fieldsMapping: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -16,7 +16,8 @@ module.exports = {
 				title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 				translateTitle: { type: 'boolean' },
 				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-				sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
+				sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
+				modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' }
 			},
 			required: ['source'],
 			additionalProperties: false

--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -15,6 +15,7 @@ const cardsModified = cards.map(card => modifySchemaThenProperties(card, {
 	properties: {
 		name: { type: 'string' },
 		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
+		actionsModalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		translateLabel: { type: 'boolean' },
 		conditions: makeConditions(false, true)
 	},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -155,6 +155,7 @@
     "massiveActions": {
         "title": "common.title",
         "translateTitle": true,
+        "modalSize": "large",
         "source": {
             "service": "serviceName",
             "namespace": "namespaceName",

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -83,6 +83,7 @@ collapseSections: true
 remoteActions:
   title: views.title.someTitle
   translateTitle: true
+  modalSize: extra-large
   source:
     service: serviceName
     namespace: namespaceName
@@ -259,6 +260,7 @@ sections:
         iconColor: colorName
         color: colorName
         backgroundColor: colorName
+        modalSize: medium
         callback:
           name: redirect
           props:
@@ -632,6 +634,7 @@ sections:
         component: Location
         componentAttributes:
           label: some.traduction.label
+          modalSize: small
           markers:
             icon: iconName
             color: colorName

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -180,6 +180,7 @@
     "massiveActions": {
         "title": "common.title",
         "translateTitle": true,
+        "modalSize": "large",
         "source": {
             "service": "serviceName",
             "namespace": "namespaceName",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -132,6 +132,7 @@
     "remoteActions": {
         "title": "views.title.someTitle",
         "translateTitle": true,
+        "modalSize": "extra-large",
         "source": {
             "service": "serviceName",
             "namespace": "namespaceName",
@@ -400,6 +401,7 @@
                     "iconColor": "colorName",
                     "color": "colorName",
                     "backgroundColor": "colorName",
+                    "modalSize": "medium",
                     "callback": {
                         "name": "redirect",
                         "props": {
@@ -1015,6 +1017,7 @@
                             "component": "Location",
                             "componentAttributes": {
                                 "label": "some.traduction.label",
+                                "modalSize": "small",
                                 "markers": {
                                     "icon": "iconName",
                                     "color": "colorName",

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -189,6 +189,7 @@
             "component": "BaseCard",
             "label": "some.label.key",
             "translateLabel": false,
+            "actionsModalSize": "large",
             "actions": [
                 {
                     "name": "testEndpoint",
@@ -247,6 +248,7 @@
                     "type": "form",
                     "callback": "reloadData",
                     "componentAttributes": {
+                        "modalSize": "mobile",
                         "endpoint": {
                             "service": "serviceName",
                             "namespace": "namespaceName",

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -128,6 +128,7 @@ fields:
     component: BaseCard
     label: some.label.key
     translateLabel: false
+    actionsModalSize: large
     actions:
       - name: testEndpoint
         type: endpoint
@@ -166,6 +167,7 @@ fields:
         type: form
         callback: reloadData
         componentAttributes:
+          modalSize: mobile
           endpoint:
             service: serviceName
             namespace: namespaceName


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2658

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se deberá agregar una property en los componentes que utilicen un popup para poder determinar el size:

- small
- medium
- large
- extra-large
- mobile

Se le debe agregar al los schemas de: Location, RemoteActions de edit, MassiveActions de browse, a las acciones de monitor,  Al ActionForm de topComponents y al action type form de genericActions

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las properties de `modalSize` a los componentes mencionados arriba.
Al componente de actions de monitor se agregó al baseCard la prop de `actionsModalSize`

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README