### PR TITLE
add new props for dateTimePicker

### DIFF
--- a/lib/schemas/browse/modules/filters/components/dateTimePicker.js
+++ b/lib/schemas/browse/modules/filters/components/dateTimePicker.js
@@ -14,6 +14,7 @@ module.exports = makeComponent({
 		selectRange: booleanType,
 		selectDate: booleanType,
 		selectTime: booleanType,
+		canCreateTime: booleanType,
 		format: { type: 'string' },
 		presets: {
 			oneOf: [
@@ -31,6 +32,23 @@ module.exports = makeComponent({
 					additionalProperties: false
 				}
 			]
+		},
+		timeOptions: {
+			type: 'object',
+			properties: {
+				hourLapse: { type: 'number' },
+				minuteLapse: { type: 'number' },
+				custom: {
+					type: 'array',
+					items: {
+						type: 'string',
+						pattern: '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'
+					},
+					minItems: 1
+				}
+			},
+			minProperties: 1,
+			additionalProperties: false
 		}
 	},
 	conditions: {

--- a/lib/schemas/common-sections/sections/remoteSection.js
+++ b/lib/schemas/common-sections/sections/remoteSection.js
@@ -26,7 +26,7 @@ module.exports = {
 					endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
 				},
 				required: ['type', 'endpoint'],
-				minProps: 2,
+				minProperties: 2,
 				additionalProperties: false
 			}
 		},

--- a/lib/schemas/common/browseBase/massiveActions.js
+++ b/lib/schemas/common/browseBase/massiveActions.js
@@ -15,5 +15,5 @@ module.exports = isPage => ({
 		actions: makeGenericActions({ customCallbacks })
 	},
 	additionalProperties: false,
-	minProps: 1
+	minProperties: 1
 });

--- a/lib/schemas/edit-new/modules/components/dateTimePicker.js
+++ b/lib/schemas/edit-new/modules/components/dateTimePicker.js
@@ -14,6 +14,7 @@ module.exports = makeComponent({
 		selectRange: booleanType,
 		selectDate: booleanType,
 		selectTime: booleanType,
+		canCreateTime: booleanType,
 		format: { type: 'string' },
 		presets: {
 			oneOf: [
@@ -31,6 +32,23 @@ module.exports = makeComponent({
 					additionalProperties: false
 				}
 			]
+		},
+		timeOptions: {
+			type: 'object',
+			properties: {
+				hourLapse: { type: 'number' },
+				minuteLapse: { type: 'number' },
+				custom: {
+					type: 'array',
+					items: {
+						type: 'string',
+						pattern: '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'
+					},
+					minItems: 1
+				}
+			},
+			minProperties: 1,
+			additionalProperties: false
 		}
 	},
 	conditions: {

--- a/lib/schemas/edit-new/modules/components/multiInput.js
+++ b/lib/schemas/edit-new/modules/components/multiInput.js
@@ -30,7 +30,7 @@ module.exports = makeComponent({
 								type: 'object',
 								properties: commonProps,
 								additionalProperties: false,
-								minProps: 1
+								minProperties: 1
 							}
 						},
 						additionalProperties: false,

--- a/lib/schemas/edit-new/modules/components/newDatePicker.js
+++ b/lib/schemas/edit-new/modules/components/newDatePicker.js
@@ -14,6 +14,7 @@ module.exports = makeComponent({
 		selectRange: booleanType,
 		selectDate: booleanType,
 		selectTime: booleanType,
+		canCreateTime: booleanType,
 		format: { type: 'string' },
 		presets: {
 			oneOf: [
@@ -31,6 +32,23 @@ module.exports = makeComponent({
 					additionalProperties: false
 				}
 			]
+		},
+		timeOptions: {
+			type: 'object',
+			properties: {
+				hourLapse: { type: 'number' },
+				minuteLapse: { type: 'number' },
+				custom: {
+					type: 'array',
+					items: {
+						type: 'string',
+						pattern: '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$'
+					},
+					minItems: 1
+				}
+			},
+			minProperties: 1,
+			additionalProperties: false
 		}
 	},
 	conditions: {

--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -45,7 +45,7 @@ module.exports = {
 				endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
 			},
 			required: ['type', 'endpoint'],
-			minProps: 2,
+			minProperties: 2,
 			additionalProperties: false
 		},
 		fields: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -578,6 +578,15 @@
                     "lastWeek": false,
                     "lastMonth": true,
                     "nextMonth": false
+                },
+                "canCreateTime": false,
+                "timeOptions": {
+                    "hourLapse": 2,
+                    "minuteLapse": 30,
+                    "custom": [
+                        "11:00",
+                        "20:00"
+                    ]
                 }
             }
         },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1045,6 +1045,13 @@ sections:
             useTimezone: false
             selectDate: true
             selectTime: false
+            canCreateTime: false
+            timeOptions:
+              hourLapse: 2
+              minuteLapse: 30
+              custom:
+                - '11:00'
+                - '20:00'
 
         - name: dateTime
           component: DateTimePicker

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -621,6 +621,15 @@
                     "lastWeek": false,
                     "lastMonth": true,
                     "nextMonth": false
+                },
+                "canCreateTime": false,
+                "timeOptions": {
+                    "hourLapse": 2,
+                    "minuteLapse": 30,
+                    "custom": [
+                        "11:00",
+                        "20:00"
+                    ]
                 }
             }
         },

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1645,7 +1645,16 @@
                             "componentAttributes": {
                                 "useTimezone": false,
                                 "selectDate": true,
-                                "selectTime": false
+                                "selectTime": false,
+                                "canCreateTime": false,
+                                "timeOptions": {
+                                    "hourLapse": 2,
+                                    "minuteLapse": 30,
+                                    "custom": [
+                                        "11:00",
+                                        "20:00"
+                                    ]
+                                }
                             }
                         },
                         {


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2659

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberá poder definir los rangos de valores de los horarios **timeOptions**:

Cada x hs => **hourLapse**
Cada x minutos => **minuteLapse**
Custom: => **custom**
- 14:00
- 16:00
- 18:00

No se puede ingresar un horario especifico
La idea es que si o si tengan que seleccionar del listado, cosa que si la config es Cada 1 hr, no puedan poner 14:32
La property se deberá llamar: **canCreateTime**

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregaron las properties descriptas arriba a los Componentes de dateTimePicker

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README