### PR TITLE
add mapper for monitor columns

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -7,12 +7,14 @@ const customLink = require('../common/customLink');
 const makeConditions = require('../common/conditions');
 const statusBar = require('../common/statusBar');
 const themes = require('../common/themes');
+const mapper = require('../common/mapper');
 const { modifySchemaThenProperties } = require('../utils');
 const cards = require('./cards');
 const cardNames = require('./cards/cardNames');
 
 const cardsModified = cards.map(card => modifySchemaThenProperties(card, {
 	properties: {
+		mapper,
 		name: { type: 'string' },
 		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		actionsModalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -189,6 +189,7 @@
             "component": "BaseCard",
             "label": "some.label.key",
             "translateLabel": false,
+            "mapper": "addHashtag",
             "actionsModalSize": "large",
             "actions": [
                 {

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -128,6 +128,7 @@ fields:
     component: BaseCard
     label: some.label.key
     translateLabel: false
+    mapper: addHashtag
     actionsModalSize: large
     actions:
       - name: testEndpoint


### PR DESCRIPTION
**LINK AL TICKET**

https://fizzmod.atlassian.net/browse/JMV-2688

**DESCRIPCIÓN DEL REQUERIMIENTO**

Se deberán poder agregar mappers a cada columna de monitor.

**DESCRIPCIÓN DE LA SOLUCIÓN**

Se agregó la property `mapper` para las columnas de monitores.

**CÓMO SE PUEDE PROBAR?**

Ejecutando comando de validacion de package descripto en el README