### PR TITLE
change schema monitor

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -31,6 +31,8 @@ module.exports = {
 	type: 'object',
 	properties: {
 		...properties,
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 		themes,
 		filters,
 		statusBar,

--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -19,7 +19,10 @@ const cardsModified = cards.map(card => modifySchemaThenProperties(card, {
 		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		actionsModalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		translateLabel: { type: 'boolean' },
-		conditions: makeConditions(false, true)
+		conditions: makeConditions(false, true),
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
+
 	},
 	requiredProperties: ['name']
 }));
@@ -34,10 +37,8 @@ module.exports = {
 		sortableFields,
 		featureFlags: { $ref: 'schemaDefinitions#/definitions/featureFlags' },
 		root: { const: 'Monitor' },
-		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		autoRefresh: { $ref: 'schemaDefinitions#/definitions/autoRefresh' },
 		dependencies: { $ref: 'schemaDefinitions#/definitions/dependencies' },
-		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 		cardLink: {
 			oneOf: [{ const: false }, customLink]
 		},

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -3,21 +3,6 @@
     "name": "views-demo-monitor",
     "root": "Monitor",
     "autoRefresh": 60,
-    "source": {
-        "service": "playground",
-        "namespace": "views-demo",
-        "method": "list",
-        "resolve": false
-    },
-    "endpointParameters": [
-        {
-            "name": "status",
-            "target": "filter",
-            "value": {
-                "static": "active"
-            }
-        }
-    ],
     "schemaSource": {
         "type": "dynamic",
         "endpoint": {
@@ -194,6 +179,21 @@
             "translateLabel": false,
             "mapper": "addHashtag",
             "actionsModalSize": "large",
+            "source": {
+                "service": "playground",
+                "namespace": "views-demo",
+                "method": "list",
+                "resolve": false
+            },
+            "endpointParameters": [
+                {
+                    "name": "status",
+                    "target": "filter",
+                    "value": {
+                        "static": "active"
+                    }
+                }
+            ],
             "actions": [
                 {
                     "name": "testEndpoint",
@@ -317,6 +317,21 @@
         {
             "name": "someCardTwo",
             "component": "BaseCard",
+            "source": {
+                "service": "playground",
+                "namespace": "views-demo",
+                "method": "list",
+                "resolve": false
+            },
+            "endpointParameters": [
+                {
+                    "name": "status",
+                    "target": "filter",
+                    "value": {
+                        "static": "active"
+                    }
+                }
+            ],
             "fieldsGroup": [
                 {
                     "name": "info",

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -3,6 +3,21 @@
     "name": "views-demo-monitor",
     "root": "Monitor",
     "autoRefresh": 60,
+    "source": {
+        "service": "playground",
+        "namespace": "views-demo",
+        "method": "list",
+        "resolve": false
+    },
+    "endpointParameters": [
+        {
+            "name": "status",
+            "target": "filter",
+            "value": {
+                "static": "active"
+            }
+        }
+    ],
     "schemaSource": {
         "type": "dynamic",
         "endpoint": {

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -4,18 +4,6 @@ root: Monitor
 
 autoRefresh: 60
 
-source:
-  service: playground
-  namespace: views-demo
-  method: list
-  resolve: false
-
-endpointParameters:
-  - name: status
-    target: filter
-    value:
-      static: active
-
 schemaSource:
   type: dynamic
   endpoint:
@@ -133,6 +121,16 @@ fields:
     translateLabel: false
     mapper: addHashtag
     actionsModalSize: large
+    source:
+      service: "playground"
+      namespace: "views-demo"
+      method: "list"
+      resolve: false
+    endpointParameters:
+      - name: "status"
+        target: "filter"
+        value:
+          static: "active"
     actions:
       - name: testEndpoint
         type: endpoint
@@ -204,6 +202,17 @@ fields:
 
   - name: someCardTwo
     component: BaseCard
+    source:
+      service: "playground"
+      namespace: "views-demo"
+      method: "list"
+      resolve: false
+    endpointParameters:
+      - name: "status"
+        target: "filter"
+        value:
+          static: "active"
+
     fieldsGroup:
       - name: info
         fields:
@@ -216,4 +225,3 @@ fields:
         - - name: isEqualTo
             field: name
             referenceValue: test
-

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -4,6 +4,18 @@ root: Monitor
 
 autoRefresh: 60
 
+source:
+  service: playground
+  namespace: views-demo
+  method: list
+  resolve: false
+
+endpointParameters:
+  - name: status
+    target: filter
+    value:
+      static: active
+
 schemaSource:
   type: dynamic
   endpoint:


### PR DESCRIPTION
## Link al ticket
https://fizzmod.atlassian.net/browse/JMV-2695
## Descripción del requerimiento
Se deberá mover la estructura de source y endpointParameters a cada columna

Se deberá desestimar el source y endpointParameters del route del schema

Tener en cuenta el validador

Se deberá implementar el load more en cada columna

Deberá tener el mismo funcionamiento que el actual, pero por cada columna, en caso de que existan más registros

Dicho botón de load more, solo deberá ejecutar la request de cada columna

Evitar que el load more ejecute el skeleton
## Descripción de la solución
Se pasó el source y endpointParameters del root del schema a cada fields, es decir para cada columna
