### PR TITLE
add conditional properties for custom textCardKpi graph

### DIFF
--- a/lib/schemas/common/graphs.js
+++ b/lib/schemas/common/graphs.js
@@ -40,55 +40,76 @@ const graphMappingCommonProps = {
 	additionalProperties: false
 };
 
+const baseSchemaProperties = {
+	filters,
+	component: { type: 'string' },
+	name: { type: 'string' },
+	title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
+	translateTitle: { type: 'boolean' },
+	subtitle: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
+	translateSubtitle: { type: 'boolean' },
+	source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+	endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
+	componentAttributes: { type: 'object' },
+	x: { type: 'number' },
+	y: { type: 'number' },
+	width: { type: 'number' },
+	height: {
+		oneOf: [
+			{ type: 'number' },
+			{ const: 'auto' }
+		]
+	},
+	label: graphMappingCommonProps,
+	values: {
+		type: 'array',
+		items: graphMappingCommonProps,
+		minItems: 1
+	}
+
+};
+
+const textCardKpiProperties = {
+	value: {
+		type: 'object',
+		properties: {
+			field: { type: 'string' },
+			mapper
+
+		}
+	},
+	percent: {
+		type: 'object',
+		properties: {
+			field: { type: 'string' },
+			mapper
+
+		}
+	}
+};
+
 module.exports = {
 	type: 'array',
 	items: {
 		type: 'object',
-		properties: {
-			filters,
-			component: { type: 'string' },
-			name: { type: 'string' },
-			title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
-			translateTitle: { type: 'boolean' },
-			subtitle: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
-			translateSubtitle: { type: 'boolean' },
-			source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-			endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
-			componentAttributes: { type: 'object' },
-			x: { type: 'number' },
-			y: { type: 'number' },
-			width: { type: 'number' },
-			height: {
-				oneOf: [
-					{ type: 'number' },
-					{ const: 'auto' }
-				]
-			},
-			label: graphMappingCommonProps,
-			values: {
-				type: 'array',
-				items: graphMappingCommonProps,
-				minItems: 1
-			},
-			value: {
-				type: 'object',
-				properties: {
-					field: { type: 'string' },
-					mapper
-
+		properties: baseSchemaProperties,
+		additionalProperties: true,
+		allOf: [
+			{
+				if: {
+					properties: { components: { const: 'TextCardKpi' } }
+				},
+				then: {
+					properties:
+						textCardKpiProperties,
+					required: ['component', 'name', 'x', 'y', 'width', 'height']
+				},
+				else: {
+					required: ['component', 'source', 'name', 'x', 'y', 'width', 'height']
 				}
-			},
-			percent: {
-				type: 'object',
-				properties: {
-					field: { type: 'string' },
-					mapper
 
-				}
 			}
-		},
-		additionalProperties: false,
-		required: ['component', 'source', 'name', 'x', 'y', 'width', 'height']
+		]
 	},
 	minItems: 1
 };

--- a/tests/mocks/schemas/dashboard.yml
+++ b/tests/mocks/schemas/dashboard.yml
@@ -75,5 +75,26 @@ graphs:
     y: 0
     width: 12
     height: 4
+  - component: TextCardKpi
+    name: TextCardDelivery
+    title: title
+    value:
+      field: someField
+      mapper:
+        name: suffix
+        props:
+          addWhitespace: true
+          value: 'hs'
+    percent:
+      field: someField
+      mapper:
+        name: suffix
+        props:
+          addWhitespace: true
+          value: '%'
+    x: 0
+    y: 0
+    width: 12
+    height: 4
 
 

--- a/tests/mocks/schemas/expected/dashboard.json
+++ b/tests/mocks/schemas/expected/dashboard.json
@@ -104,6 +104,36 @@
 					"y": 0,
 					"width": 12,
 					"height": 4
+				},
+				{
+					"component": "TextCardKpi",
+					"filters": [],
+					"name": "TextCardDelivery",
+					"title": "title",
+					"value": {
+						"field": "someField",
+						"mapper": {
+							"name": "suffix",
+							"props": {
+								"addWhitespace": true,
+								"value": "hs"
+							}
+						}
+					},
+					"percent": {
+						"field": "someField",
+						"mapper": {
+							"name": "suffix",
+							"props": {
+								"addWhitespace": true,
+								"value": "%"
+							}
+						}
+					},
+					"x": 0,
+					"y": 0,
+					"width": 12,
+					"height": 4
 				}
     ]
 }


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-2840
## Descripción del requerimiento
- Se creo un componente provisorio para poder contar con una Card la cual puede mostrar un Titulo, valor y porcentaje en los dashboard de KPI. El problema es que estabamos usando el schema de un graph donde se requiere tener declarado un source y en el caso que se quiera mostrar el componente TextCardKPI y solo un titulo, no era necesario tener un source declarado
## Descripción de la solución
- Por medio de condicionales, se definio que si el componente es TExtCardKpi, se agregue las properties value y percent y ademas se modifica la key required para eliminar source. 
- Tener en cuenta que esto es provisorio. Al momento de hacer el refactor de todo el dashboard vamos a volver para atras con estos cambios.
## Cómo se puede probar?
- corriendo los test. Agrege dos TextCardKpi, uno con source y otro sin source para valdiar
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```
### Added
- 
### Changed
-  schema graphs with conditional properties depends of the component name
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
