### PR TITLE
add prop required in filter schema

### DIFF
--- a/lib/schemas/browse/modules/filters/filters.js
+++ b/lib/schemas/browse/modules/filters/filters.js
@@ -13,6 +13,7 @@ module.exports = {
 			name: { type: 'string' },
 			label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 			component: { type: 'string', enum: Object.values(componentNames) },
+			required: { type: 'boolean' },
 			componentAttributes: {
 				type: 'object',
 				default: {}

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -409,6 +409,7 @@
 			"name": "filterInput",
 			"label": "test.test.test",
 			"component": "Input",
+			"required": true,
 			"componentAttributes": {
 				"icon": "iconName"
 			}

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -455,6 +455,7 @@
 		{
 			"name": "filterInput",
 			"label": "test.test.test",
+			"required": true,
 			"component": "Input",
 			"componentAttributes": {
 				"icon": "iconName"


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-2791
## Descripción del requerimiento
- Se requiere poder definir en ciertas vistas filtros como requerido obligando al usuario a usar algunos de ellos para poder mostrar informacion
## Descripción de la solución
- Se agrego la prop required con tipo boolean
## Cómo se puede probar?
- corriendo los test, agregue en el browse el filtro filterInput la prop required en true
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```
### Added
- key required in filter schema
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
