### PR TITLE
Jmv 2915 schema property redirect

### DIFF
--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -1,35 +1,50 @@
-'use strict';
+"use strict";
 
-const { properties, required } = require('../common/base');
-const action = require('../common/actions/action');
-const makeConditions = require('../common/conditions');
-const getBrowseBaseSchema = require('../common/browseBase');
-const makeTopComponents = require('../common/topComponents');
-const makeActionCallbacks = require('../common/actionCallbacks');
+const { properties, required } = require("../common/base");
+const action = require("../common/actions/action");
+const makeConditions = require("../common/conditions");
+const getBrowseBaseSchema = require("../common/browseBase");
+const makeTopComponents = require("../common/topComponents");
+const makeActionCallbacks = require("../common/actionCallbacks");
+const redirect = require("../common/redirect");
 
 const conditions = makeConditions();
 
 const makeCustomAction = () => ({
-	...action,
-	properties: {
-		...action.properties,
-		conditions,
-		callback: makeActionCallbacks({ customCallbacks: [] })
-	}
+  ...action,
+  properties: {
+    ...action.properties,
+    conditions,
+    callback: makeActionCallbacks({ customCallbacks: [] }),
+  },
 });
 
+const defaultBrowseSchema = {
+  type: "object",
+  properties: {
+    ...properties,
+    ...getBrowseBaseSchema(true),
+    topComponents: makeTopComponents(true),
+    root: { const: "Browse" },
+    actions: {
+      type: "array",
+      items: makeCustomAction(),
+    },
+  },
+  additionalProperties: false,
+  required: [...required, "fields", "source"],
+};
+
 module.exports = {
-	type: 'object',
-	properties: {
-		...properties,
-		...getBrowseBaseSchema(true),
-		topComponents: makeTopComponents(true),
-		root: { const: 'Browse' },
-		actions: {
-			type: 'array',
-			items: makeCustomAction()
-		}
-	},
-	additionalProperties: false,
-	required: [...required, 'fields', 'source']
+  allOf: [
+    {
+      if: {
+        properties: {
+          redirect: { type: "object" },
+        },
+      },
+      then: redirect,
+      else: defaultBrowseSchema,
+    },
+  ],
 };

--- a/lib/schemas/browse/schema.js
+++ b/lib/schemas/browse/schema.js
@@ -1,50 +1,45 @@
-"use strict";
+'use strict';
 
-const { properties, required } = require("../common/base");
-const action = require("../common/actions/action");
-const makeConditions = require("../common/conditions");
-const getBrowseBaseSchema = require("../common/browseBase");
-const makeTopComponents = require("../common/topComponents");
-const makeActionCallbacks = require("../common/actionCallbacks");
-const redirect = require("../common/redirect");
+const { properties, required } = require('../common/base');
+const action = require('../common/actions/action');
+const makeConditions = require('../common/conditions');
+const getBrowseBaseSchema = require('../common/browseBase');
+const makeTopComponents = require('../common/topComponents');
+const makeActionCallbacks = require('../common/actionCallbacks');
+const redirect = require('../common/redirect');
 
 const conditions = makeConditions();
-
 const makeCustomAction = () => ({
-  ...action,
-  properties: {
-    ...action.properties,
-    conditions,
-    callback: makeActionCallbacks({ customCallbacks: [] }),
-  },
+	...action,
+	properties: {
+		...action.properties,
+		conditions,
+		callback: makeActionCallbacks({ customCallbacks: [] })
+	}
 });
-
-const defaultBrowseSchema = {
-  type: "object",
-  properties: {
-    ...properties,
-    ...getBrowseBaseSchema(true),
-    topComponents: makeTopComponents(true),
-    root: { const: "Browse" },
-    actions: {
-      type: "array",
-      items: makeCustomAction(),
-    },
-  },
-  additionalProperties: false,
-  required: [...required, "fields", "source"],
-};
-
 module.exports = {
-  allOf: [
-    {
-      if: {
-        properties: {
-          redirect: { type: "object" },
-        },
-      },
-      then: redirect,
-      else: defaultBrowseSchema,
-    },
-  ],
+	type: 'object',
+	properties: {
+		redirect,
+		...properties,
+		...getBrowseBaseSchema(true),
+		topComponents: makeTopComponents(true),
+		root: { const: 'Browse' },
+		actions: {
+			type: 'array',
+			items: makeCustomAction()
+		}
+	},
+	if: {
+		properties: {
+			redirect: { $ref: 'schemaDefinitions#/definitions/redirect' }
+		}
+	},
+	then: {
+		required: [...required]
+	},
+	else: {
+		additionalProperties: false,
+		required: ['fields', 'source', ...required]
+	}
 };

--- a/lib/schemas/common/redirect.js
+++ b/lib/schemas/common/redirect.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const source = require("./endpoint");
+const endpointParameters = require("./endpointParameters");
+
+module.exports = {
+  type: "object",
+  properties: {
+    source,
+  },
+  additionalProperties: endpointParameters,
+  required: ["source"],
+};

--- a/lib/schemas/common/redirect.js
+++ b/lib/schemas/common/redirect.js
@@ -1,13 +1,12 @@
-"use strict";
-
-const source = require("./endpoint");
-const endpointParameters = require("./endpointParameters");
+'use strict';
 
 module.exports = {
-  type: "object",
-  properties: {
-    source,
-  },
-  additionalProperties: endpointParameters,
-  required: ["source"],
+	type: 'object',
+	properties: {
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: {
+			$ref: 'schemaDefinitions#/definitions/endpointParameters'
+		}
+	},
+	required: ['source']
 };

--- a/lib/schemas/definitions/index.js
+++ b/lib/schemas/definitions/index.js
@@ -11,6 +11,7 @@ const graphs = require('../common/graphs');
 const modalSize = require('../common/modalSize');
 const template = require('../common/template');
 const featureFlags = require('../common/featureFlags');
+const redirect = require('../common/redirect');
 
 module.exports = {
 	$id: 'schemaDefinitions',
@@ -18,6 +19,7 @@ module.exports = {
 		browseField,
 		editNewField,
 		endpoint,
+		redirect,
 		dependencies,
 		stringPrefix,
 		autoRefresh,

--- a/lib/schemas/edit-new/schema.js
+++ b/lib/schemas/edit-new/schema.js
@@ -4,11 +4,13 @@ const { properties, required } = require('../common/base');
 const makeSections = require('../common-sections');
 const sectionNames = require('./modules/sectionsNames');
 const header = require('./modules/headerProperties');
+const redirect = require('../common/redirect');
 
 module.exports = {
 	type: 'object',
 	properties: {
 		...properties,
+		redirect,
 		header,
 		saveRedirectUrl: { type: 'string' },
 		cancelRedirectUrl: { type: 'string' },
@@ -18,6 +20,16 @@ module.exports = {
 		collapseSections: { type: 'boolean' },
 		sections: makeSections(sectionNames)
 	},
-	additionalProperties: false,
-	required: [...required, 'sections']
+	if: {
+		properties: {
+			redirect: { $ref: 'schemaDefinitions#/definitions/redirect' }
+		}
+	},
+	then: {
+		required: [...required]
+	},
+	else: {
+		additionalProperties: false,
+		required: [...required, 'sections']
+	}
 };

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const { properties, required } = require('../edit-new/schema');
+const { properties, if: conditonal, then: isTrue, else: isFalse } = require('../edit-new/schema');
 const themes = require('../common/themes');
+const redirect = require('../common/redirect');
 
 module.exports = {
 	properties: {
 		...properties,
+		redirect,
 		themes,
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		canPrint: { type: 'boolean' },
@@ -23,5 +25,7 @@ module.exports = {
 			additionalProperties: false
 		}
 	},
-	required: [...required]
+	if: conditonal,
+	then: isTrue,
+	else: isFalse
 };

--- a/lib/schemas/new/schema.js
+++ b/lib/schemas/new/schema.js
@@ -4,5 +4,5 @@ const newEditSchema = require('../edit-new/schema');
 
 module.exports = {
 	...newEditSchema,
-	required: [...newEditSchema.required, 'target']
+	else: [...newEditSchema.else.required, 'target']
 };


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-2880
## Descripción del requerimiento
- Debido a que se esta creando un microservicio nuevo Conversation en donde se reuniran todas las comunicaciones de forma externa (emails, mensajes de texto, Whatss App, se necesita que las vistas de los templates del MS mailing, dejen de existir para redireccionar a los templates de Conversation.
## Descripción de la solución
- Se agregaron en los schemas browse/edit la nueva property redirect 
## Cómo se puede probar?
- Caso Browse 
- ```
redirect:
  source:
    service: conversation
    namespace: template
    method: browse
```
```
Caso Edit:
  source:
    service: conversation
    namespace: template
    method: edit
```
para los casos de pruebas puedes añadir ese fragmento a los archivos `browse.json, edit.json, edit-with-refs-resolved.json` en las carpetas mocks y expected
## Link a la documentación
-
## Datos extra a tener en cuenta
- el ticket especifica solo en browse y edit, pero deje codigo reusable en caso que se requiera redirect en otras vistas.
## Changelog
```
### Added
- 
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
