### PR TITLE
Agregado actions a Edit

### DIFF
--- a/lib/deprecation-validators/index.js
+++ b/lib/deprecation-validators/index.js
@@ -4,10 +4,12 @@ const title = require('./title-deprecation');
 const titleComponents = require('./title-components-deprecation');
 const staticFilters = require('./static-filters-deprecation');
 const pathQuery = require('./path-query-deprecation');
+const remoteAction = require('./remoteActions-deprecation');
 
 module.exports = {
 	title,
 	titleComponents,
 	staticFilters,
-	pathQuery
+	pathQuery,
+	remoteAction
 };

--- a/lib/deprecation-validators/remoteActions-deprecation.js
+++ b/lib/deprecation-validators/remoteActions-deprecation.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { getDaysToRemoveFeatureMessage, isEdit } = require('../helpers');
+
+module.exports = class RemoteActionsDeprecation {
+
+	static getDayToRemove() {
+		return '07/15/2023';
+	}
+
+	static getDeprecatedMessage() {
+
+		return `The property \`remoteActions\` is going to be deprecated. ${getDaysToRemoveFeatureMessage(this.getDayToRemove())}`;
+	}
+
+	static validate(schema) {
+
+		if(isEdit(schema))
+			return JSON.stringify(schema).indexOf('remoteActions') === -1;
+	}
+};

--- a/lib/schemas/common/actions.js
+++ b/lib/schemas/common/actions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const getEndpointParameters = require('./endpointParameters');
 const makeGenericActions = require('../common/generic-actions');
 
 const customCallbacks = ['removeRow', 'reloadRow', 'reloadBrowse'];
@@ -11,7 +10,7 @@ module.exports = ({
 		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		translateTitle: { type: 'boolean' },
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-		endpointParameters: getEndpointParameters(false),
+		sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		actions: makeGenericActions({ customCallbacks })
 	},

--- a/lib/schemas/common/actions.js
+++ b/lib/schemas/common/actions.js
@@ -22,7 +22,7 @@ module.exports = ({
 		},
 		{
 			required: [
-				'source', 'sourceEndpointParameters'
+				'source'
 			]
 		}
 	],

--- a/lib/schemas/common/actions.js
+++ b/lib/schemas/common/actions.js
@@ -12,12 +12,12 @@ module.exports = ({
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
-		actions: makeGenericActions({ customCallbacks })
+		staticActions: makeGenericActions({ customCallbacks })
 	},
 	anyOf: [
 		{
 			required: [
-				'actions'
+				'staticActions'
 			]
 		},
 		{

--- a/lib/schemas/common/actions.js
+++ b/lib/schemas/common/actions.js
@@ -14,6 +14,17 @@ module.exports = ({
 		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		actions: makeGenericActions({ customCallbacks })
 	},
-	additionalProperties: false,
-	minProperties: 1
+	anyOf: [
+		{
+			required: [
+				'actions'
+			]
+		},
+		{
+			required: [
+				'source', 'sourceEndpointParameters'
+			]
+		}
+	],
+	additionalProperties: false
 });

--- a/lib/schemas/common/actions.js
+++ b/lib/schemas/common/actions.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const getEndpointParameters = require('./endpointParameters');
+const makeGenericActions = require('../common/generic-actions');
+
+const customCallbacks = ['removeRow', 'reloadRow', 'reloadBrowse'];
+
+module.exports = ({
+	type: 'object',
+	properties: {
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
+		translateTitle: { type: 'boolean' },
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: getEndpointParameters(false),
+		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
+		actions: makeGenericActions({ customCallbacks })
+	},
+	additionalProperties: false,
+	minProperties: 1
+});

--- a/lib/schemas/common/remoteActions.js
+++ b/lib/schemas/common/remoteActions.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+	type: 'object',
+	properties: {
+		title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
+		translateTitle: { type: 'boolean' },
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
+		modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' }
+	},
+	required: ['source'],
+	additionalProperties: false
+};

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -2,6 +2,8 @@
 
 const { properties, if: conditonal, then: isTrue, else: isFalse } = require('../edit-new/schema');
 const themes = require('../common/themes');
+const actions = require('../common/actions');
+const remoteActions = require('../common/remoteActions');
 
 module.exports = {
 	properties: {
@@ -10,20 +12,31 @@ module.exports = {
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		canPrint: { type: 'boolean' },
 		dependencies: { $ref: 'schemaDefinitions#/definitions/dependencies' },
-		remoteActions: {
-			type: 'object',
-			properties: {
-				title: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
-				translateTitle: { type: 'boolean' },
-				source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-				sourceEndpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
-				modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' }
-			},
-			required: ['source'],
-			additionalProperties: false
-		}
+		actions,
+		remoteActions
 	},
-	if: conditonal,
-	then: isTrue,
-	else: isFalse
+	allOf: [
+		{
+			if: conditonal,
+			then: isTrue,
+			else: isFalse
+		},
+		{
+			if: {
+				properties: { actions: { const: false } }
+			},
+			then: {
+				not: {
+					properties: { actions },
+					required: ['actions']
+				}
+			},
+			else: {
+				not: {
+					properties: { remoteActions },
+					required: ['remoteActions']
+				}
+			}
+		}
+	]
 };

--- a/lib/schemas/edit/schema.js
+++ b/lib/schemas/edit/schema.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { properties, if: conditonal, then: isTrue, else: isFalse } = require('../edit-new/schema');
+const { properties, if: conditional, then: isTrue, else: isFalse } = require('../edit-new/schema');
 const themes = require('../common/themes');
 const actions = require('../common/actions');
 const remoteActions = require('../common/remoteActions');
@@ -17,7 +17,7 @@ module.exports = {
 	},
 	allOf: [
 		{
-			if: conditonal,
+			if: conditional,
 			then: isTrue,
 			else: isFalse
 		},

--- a/tests/mocks/schemas/edit-with-actions-source.yml
+++ b/tests/mocks/schemas/edit-with-actions-source.yml
@@ -80,6 +80,20 @@ dependencies:
           static: status
     targetField: fieldNameOne
 collapseSections: true
+actions:
+  title: common.title
+  translateTitle: true
+  modalSize: large
+  source:
+    service: serviceName
+    namespace: namespaceName
+    method: methodName
+    resolve: false
+  sourceEndpointParameters:
+    - name: status
+      target: query
+      value:
+        static: active
 sections:
   - name: mainFormSection
     rootComponent: MainForm

--- a/tests/mocks/schemas/edit-with-actions-source.yml
+++ b/tests/mocks/schemas/edit-with-actions-source.yml
@@ -91,7 +91,7 @@ actions:
     resolve: false
   sourceEndpointParameters:
     - name: status
-      target: query
+      target: queryString
       value:
         static: active
 sections:
@@ -151,7 +151,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: active
             targetField: fieldNameThree
@@ -244,7 +244,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -583,7 +583,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -770,7 +770,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
               source:
@@ -789,7 +789,7 @@ sections:
             componentAttributes:
               endpointParameters:
                 - name: id
-                  target: query
+                  target: queryString
                   value:
                     dynamic: userIds
               source:
@@ -837,7 +837,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -855,7 +855,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 dataMapping:
@@ -1007,7 +1007,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1096,7 +1096,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1361,11 +1361,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: "string"
@@ -1522,7 +1522,7 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     filesTypes:
@@ -1545,11 +1545,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: string
@@ -1614,7 +1614,7 @@ sections:
         value:
           dynamic: id
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     includeDataFrom:
@@ -1842,7 +1842,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: 1
       - name: stepsExample

--- a/tests/mocks/schemas/edit-with-actions-static.yml
+++ b/tests/mocks/schemas/edit-with-actions-static.yml
@@ -84,7 +84,7 @@ actions:
   title: common.title
   translateTitle: true
   modalSize: large
-  actions:
+  staticActions:
     - name: testEndpoint
       type: endpoint
       callback: refresh

--- a/tests/mocks/schemas/edit-with-actions-static.yml
+++ b/tests/mocks/schemas/edit-with-actions-static.yml
@@ -80,6 +80,26 @@ dependencies:
           static: status
     targetField: fieldNameOne
 collapseSections: true
+actions:
+  title: common.title
+  translateTitle: true
+  modalSize: large
+  actions:
+    - name: testEndpoint
+      type: endpoint
+      callback: refresh
+      componentAttributes:
+        icon: box
+        endpoint:
+          service: serviceName
+          namespace: namespaceName
+          method: methodName
+          resolve: false
+        endpointParameters:
+          - name: id
+            target: path
+            value:
+              dynamic: id
 sections:
   - name: mainFormSection
     rootComponent: MainForm

--- a/tests/mocks/schemas/edit-with-actions-static.yml
+++ b/tests/mocks/schemas/edit-with-actions-static.yml
@@ -157,7 +157,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: active
             targetField: fieldNameThree
@@ -250,7 +250,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -589,7 +589,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -776,7 +776,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
               source:
@@ -795,7 +795,7 @@ sections:
             componentAttributes:
               endpointParameters:
                 - name: id
-                  target: query
+                  target: queryString
                   value:
                     dynamic: userIds
               source:
@@ -843,7 +843,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -861,7 +861,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 dataMapping:
@@ -1013,7 +1013,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1102,7 +1102,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1367,11 +1367,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: "string"
@@ -1528,7 +1528,7 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     filesTypes:
@@ -1551,11 +1551,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: string
@@ -1620,7 +1620,7 @@ sections:
         value:
           dynamic: id
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     includeDataFrom:
@@ -1848,7 +1848,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: 1
       - name: stepsExample

--- a/tests/mocks/schemas/edit-with-actions.yml
+++ b/tests/mocks/schemas/edit-with-actions.yml
@@ -94,7 +94,7 @@ actions:
       target: query
       value:
         static: active
-  actions:
+  staticActions:
     - name: testEndpoint
       type: endpoint
       callback: refresh

--- a/tests/mocks/schemas/edit-with-actions.yml
+++ b/tests/mocks/schemas/edit-with-actions.yml
@@ -91,7 +91,7 @@ actions:
     resolve: false
   sourceEndpointParameters:
     - name: status
-      target: query
+      target: queryString
       value:
         static: active
   staticActions:
@@ -167,7 +167,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: active
             targetField: fieldNameThree
@@ -260,7 +260,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -599,7 +599,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -786,7 +786,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
               source:
@@ -805,7 +805,7 @@ sections:
             componentAttributes:
               endpointParameters:
                 - name: id
-                  target: query
+                  target: queryString
                   value:
                     dynamic: userIds
               source:
@@ -853,7 +853,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -871,7 +871,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 dataMapping:
@@ -1023,7 +1023,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1112,7 +1112,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1377,11 +1377,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: "string"
@@ -1538,7 +1538,7 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     filesTypes:
@@ -1561,11 +1561,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: string
@@ -1630,7 +1630,7 @@ sections:
         value:
           dynamic: id
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     includeDataFrom:
@@ -1858,7 +1858,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: 1
       - name: stepsExample

--- a/tests/mocks/schemas/edit-with-actions.yml
+++ b/tests/mocks/schemas/edit-with-actions.yml
@@ -80,6 +80,36 @@ dependencies:
           static: status
     targetField: fieldNameOne
 collapseSections: true
+actions:
+  title: common.title
+  translateTitle: true
+  modalSize: large
+  source:
+    service: serviceName
+    namespace: namespaceName
+    method: methodName
+    resolve: false
+  sourceEndpointParameters:
+    - name: status
+      target: query
+      value:
+        static: active
+  actions:
+    - name: testEndpoint
+      type: endpoint
+      callback: refresh
+      componentAttributes:
+        icon: box
+        endpoint:
+          service: serviceName
+          namespace: namespaceName
+          method: methodName
+          resolve: false
+        endpointParameters:
+          - name: id
+            target: path
+            value:
+              dynamic: id
 sections:
   - name: mainFormSection
     rootComponent: MainForm

--- a/tests/mocks/schemas/edit-with-remote-actions.yml
+++ b/tests/mocks/schemas/edit-with-remote-actions.yml
@@ -80,6 +80,25 @@ dependencies:
           static: status
     targetField: fieldNameOne
 collapseSections: true
+remoteActions:
+  title: views.title.someTitle
+  translateTitle: true
+  modalSize: extra-large
+  source:
+    service: serviceName
+    namespace: namespaceName
+    method: methodName
+    resolve: false
+  sourceEndpointParameters:
+    - name: status
+      target: path
+      value:
+        dynamic: id
+    - name: status
+      target: query
+      mapper: booleanToStatus
+      value:
+        static: true
 sections:
   - name: mainFormSection
     rootComponent: MainForm

--- a/tests/mocks/schemas/edit-with-remote-actions.yml
+++ b/tests/mocks/schemas/edit-with-remote-actions.yml
@@ -95,7 +95,7 @@ remoteActions:
       value:
         dynamic: id
     - name: status
-      target: query
+      target: queryString
       mapper: booleanToStatus
       value:
         static: true
@@ -156,7 +156,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: active
             targetField: fieldNameThree
@@ -249,7 +249,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -588,7 +588,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -775,7 +775,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
               source:
@@ -794,7 +794,7 @@ sections:
             componentAttributes:
               endpointParameters:
                 - name: id
-                  target: query
+                  target: queryString
                   value:
                     dynamic: userIds
               source:
@@ -842,7 +842,7 @@ sections:
                   value:
                     dynamic: id
                 - name: status
-                  target: query
+                  target: queryString
                   value:
                     static: 1
 
@@ -860,7 +860,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 dataMapping:
@@ -1012,7 +1012,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1101,7 +1101,7 @@ sections:
                     value:
                       dynamic: id
                   - name: status
-                    target: query
+                    target: queryString
                     value:
                       static: 1
                 valuesMapper:
@@ -1366,11 +1366,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: "string"
@@ -1527,7 +1527,7 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     filesTypes:
@@ -1550,11 +1550,11 @@ sections:
         value:
           dynamic: statusId
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
       - name: status
-        target: query
+        target: queryString
         value:
           static:
             id: string
@@ -1619,7 +1619,7 @@ sections:
         value:
           dynamic: id
       - name: status
-        target: query
+        target: queryString
         value:
           static: 1
     includeDataFrom:
@@ -1847,7 +1847,7 @@ sections:
                 value:
                   dynamic: id
               - name: status
-                target: query
+                target: queryString
                 value:
                   static: 1
       - name: stepsExample

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -80,25 +80,56 @@ dependencies:
           static: status
     targetField: fieldNameOne
 collapseSections: true
-remoteActions:
-  title: views.title.someTitle
+actions:
+  title: common.title
   translateTitle: true
-  modalSize: extra-large
+  modalSize: large
   source:
     service: serviceName
     namespace: namespaceName
     method: methodName
     resolve: false
-  sourceEndpointParameters:
-    - name: status
-      target: path
-      value:
-        dynamic: id
+  endpointParameters:
     - name: status
       target: query
-      mapper: booleanToStatus
       value:
-        static: true
+        static: active
+  actions:
+    - name: testEndpoint
+      type: endpoint
+      callback: refresh
+      componentAttributes:
+        icon: box
+        endpoint:
+          service: serviceName
+          namespace: namespaceName
+          method: methodName
+          resolve: false
+        endpointParameters:
+          - name: id
+            target: path
+            value:
+              dynamic: id
+# RemoteActions cant be together with actions
+#remoteActions:
+#  title: views.title.someTitle
+#  translateTitle: true
+#  modalSize: extra-large
+#  source:
+#    service: serviceName
+#    namespace: namespaceName
+#    method: methodName
+#    resolve: false
+#  sourceEndpointParameters:
+#    - name: status
+#      target: path
+#      value:
+#        dynamic: id
+#    - name: status
+#      target: query
+#      mapper: booleanToStatus
+#      value:
+#        static: true
 sections:
   - name: mainFormSection
     rootComponent: MainForm

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -89,7 +89,7 @@ actions:
     namespace: namespaceName
     method: methodName
     resolve: false
-  endpointParameters:
+  sourceEndpointParameters:
     - name: status
       target: query
       value:

--- a/tests/mocks/schemas/expected/edit-with-actions-source.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-source.json
@@ -142,7 +142,7 @@
 		"sourceEndpointParameters": [
 			{
 				"name": "status",
-				"target": "query",
+				"target": "queryString",
 				"value": {
 					"static": "active"
 				}
@@ -235,7 +235,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": "active"
 									}
@@ -375,7 +375,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -924,7 +924,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1226,7 +1226,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1255,7 +1255,7 @@
 								"endpointParameters": [
 									{
 										"name": "id",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"dynamic": "userIds"
 										}
@@ -1324,7 +1324,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1354,7 +1354,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1583,7 +1583,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1710,7 +1710,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -2056,14 +2056,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2399,7 +2399,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2428,14 +2428,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2522,7 +2522,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2918,7 +2918,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": 1
 									}

--- a/tests/mocks/schemas/expected/edit-with-actions-source.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-source.json
@@ -129,6 +129,26 @@
 		}
 	],
 	"collapseSections": true,
+	"actions": {
+		"title": "common.title",
+		"translateTitle": true,
+		"modalSize": "large",
+		"source": {
+			"service": "serviceName",
+			"namespace": "namespaceName",
+			"method": "methodName",
+			"resolve": false
+		},
+		"sourceEndpointParameters": [
+			{
+				"name": "status",
+				"target": "query",
+				"value": {
+					"static": "active"
+				}
+			}
+		]
+	},
 	"sections": [
 		{
 			"name": "mainFormSection",

--- a/tests/mocks/schemas/expected/edit-with-actions-static.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-static.json
@@ -129,6 +129,36 @@
 		}
 	],
 	"collapseSections": true,
+	"actions": {
+		"title": "common.title",
+		"translateTitle": true,
+		"modalSize": "large",
+		"actions": [
+			{
+				"name": "testEndpoint",
+				"type": "endpoint",
+				"callback": "refresh",
+				"componentAttributes": {
+					"icon": "box",
+					"endpoint": {
+						"service": "serviceName",
+						"namespace": "namespaceName",
+						"method": "methodName",
+						"resolve": false
+					},
+					"endpointParameters": [
+						{
+							"name": "id",
+							"target": "path",
+							"value": {
+								"dynamic": "id"
+							}
+						}
+					]
+				}
+			}
+		]
+	},
 	"sections": [
 		{
 			"name": "mainFormSection",

--- a/tests/mocks/schemas/expected/edit-with-actions-static.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-static.json
@@ -133,7 +133,7 @@
 		"title": "common.title",
 		"translateTitle": true,
 		"modalSize": "large",
-		"actions": [
+		"staticActions": [
 			{
 				"name": "testEndpoint",
 				"type": "endpoint",

--- a/tests/mocks/schemas/expected/edit-with-actions-static.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-static.json
@@ -245,7 +245,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": "active"
 									}
@@ -385,7 +385,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -934,7 +934,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1236,7 +1236,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1265,7 +1265,7 @@
 								"endpointParameters": [
 									{
 										"name": "id",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"dynamic": "userIds"
 										}
@@ -1334,7 +1334,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1364,7 +1364,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1593,7 +1593,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1720,7 +1720,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -2066,14 +2066,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2409,7 +2409,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2438,14 +2438,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2532,7 +2532,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2928,7 +2928,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": 1
 									}

--- a/tests/mocks/schemas/expected/edit-with-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-actions.json
@@ -148,7 +148,7 @@
 				}
 			}
 		],
-		"actions": [
+		"staticActions": [
 			{
 				"name": "testEndpoint",
 				"type": "endpoint",

--- a/tests/mocks/schemas/expected/edit-with-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-actions.json
@@ -142,7 +142,7 @@
 		"sourceEndpointParameters": [
 			{
 				"name": "status",
-				"target": "query",
+				"target": "queryString",
 				"value": {
 					"static": "active"
 				}
@@ -260,7 +260,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": "active"
 									}
@@ -400,7 +400,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -949,7 +949,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1251,7 +1251,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1280,7 +1280,7 @@
 								"endpointParameters": [
 									{
 										"name": "id",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"dynamic": "userIds"
 										}
@@ -1349,7 +1349,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1379,7 +1379,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1608,7 +1608,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1735,7 +1735,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -2081,14 +2081,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2424,7 +2424,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2453,14 +2453,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2547,7 +2547,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2943,7 +2943,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": 1
 									}

--- a/tests/mocks/schemas/expected/edit-with-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-actions.json
@@ -129,6 +129,51 @@
 		}
 	],
 	"collapseSections": true,
+	"actions": {
+		"title": "common.title",
+		"translateTitle": true,
+		"modalSize": "large",
+		"source": {
+			"service": "serviceName",
+			"namespace": "namespaceName",
+			"method": "methodName",
+			"resolve": false
+		},
+		"sourceEndpointParameters": [
+			{
+				"name": "status",
+				"target": "query",
+				"value": {
+					"static": "active"
+				}
+			}
+		],
+		"actions": [
+			{
+				"name": "testEndpoint",
+				"type": "endpoint",
+				"callback": "refresh",
+				"componentAttributes": {
+					"icon": "box",
+					"endpoint": {
+						"service": "serviceName",
+						"namespace": "namespaceName",
+						"method": "methodName",
+						"resolve": false
+					},
+					"endpointParameters": [
+						{
+							"name": "id",
+							"target": "path",
+							"value": {
+								"dynamic": "id"
+							}
+						}
+					]
+				}
+			}
+		]
+	},
 	"sections": [
 		{
 			"name": "mainFormSection",

--- a/tests/mocks/schemas/expected/edit-with-remote-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-remote-actions.json
@@ -129,6 +129,34 @@
 		}
 	],
 	"collapseSections": true,
+	"remoteActions": {
+		"title": "views.title.someTitle",
+		"translateTitle": true,
+		"modalSize": "extra-large",
+		"source": {
+		  "service": "serviceName",
+		  "namespace": "namespaceName",
+		  "method": "methodName",
+		  "resolve": false
+		},
+		"sourceEndpointParameters": [
+		  {
+			"name": "status",
+			"target": "path",
+			"value": {
+			  "dynamic": "id"
+			}
+		  },
+		  {
+			"name": "status",
+			"target": "query",
+			"mapper": "booleanToStatus",
+			"value": {
+			  "static": true
+			}
+		  }
+		]
+	},
 	"sections": [
 		{
 			"name": "mainFormSection",

--- a/tests/mocks/schemas/expected/edit-with-remote-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-remote-actions.json
@@ -149,7 +149,7 @@
 		  },
 		  {
 			"name": "status",
-			"target": "query",
+			"target": "queryString",
 			"mapper": "booleanToStatus",
 			"value": {
 			  "static": true
@@ -243,7 +243,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": "active"
 									}
@@ -383,7 +383,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -932,7 +932,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1234,7 +1234,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1263,7 +1263,7 @@
 								"endpointParameters": [
 									{
 										"name": "id",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"dynamic": "userIds"
 										}
@@ -1332,7 +1332,7 @@
 									},
 									{
 										"name": "status",
-										"target": "query",
+										"target": "queryString",
 										"value": {
 											"static": 1
 										}
@@ -1362,7 +1362,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1591,7 +1591,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -1718,7 +1718,7 @@
 										},
 										{
 											"name": "status",
-											"target": "query",
+											"target": "queryString",
 											"value": {
 												"static": 1
 											}
@@ -2064,14 +2064,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2407,7 +2407,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2436,14 +2436,14 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": {
 							"id": "string"
@@ -2530,7 +2530,7 @@
 				},
 				{
 					"name": "status",
-					"target": "query",
+					"target": "queryString",
 					"value": {
 						"static": 1
 					}
@@ -2926,7 +2926,7 @@
 								},
 								{
 									"name": "status",
-									"target": "query",
+									"target": "queryString",
 									"value": {
 										"static": 1
 									}

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -139,7 +139,7 @@
 			"method": "methodName",
 			"resolve": false
 		},
-		"endpointParameters": [
+		"sourceEndpointParameters": [
 			{
 				"name": "status",
 				"target": "query",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -129,30 +129,47 @@
 		}
 	],
 	"collapseSections": true,
-	"remoteActions": {
-		"title": "views.title.someTitle",
+	"actions": {
+		"title": "common.title",
 		"translateTitle": true,
-		"modalSize": "extra-large",
+		"modalSize": "large",
 		"source": {
 			"service": "serviceName",
 			"namespace": "namespaceName",
 			"method": "methodName",
 			"resolve": false
 		},
-		"sourceEndpointParameters": [
-			{
-				"name": "status",
-				"target": "path",
-				"value": {
-					"dynamic": "id"
-				}
-			},
+		"endpointParameters": [
 			{
 				"name": "status",
 				"target": "query",
-				"mapper": "booleanToStatus",
 				"value": {
-					"static": true
+					"static": "active"
+				}
+			}
+		],
+		"actions": [
+			{
+				"name": "testEndpoint",
+				"type": "endpoint",
+				"callback": "refresh",
+				"componentAttributes": {
+					"icon": "box",
+					"endpoint": {
+						"service": "serviceName",
+						"namespace": "namespaceName",
+						"method": "methodName",
+						"resolve": false
+					},
+					"endpointParameters": [
+						{
+							"name": "id",
+							"target": "path",
+							"value": {
+								"dynamic": "id"
+							}
+						}
+					]
 				}
 			}
 		]

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -10,6 +10,14 @@ const browseSchemaJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/b
 const browseSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/browse.json');
 const editSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit.yml');
 const editSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit.json');
+const editWithActionsSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-actions.yml');
+const editWithActionsSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-actions.json');
+const editWithActionsStaticSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-actions-static.yml');
+const editWithActionsStaticSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-actions-static.json');
+const editWithActionsSourceSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-actions-source.yml');
+const editWithActionsSourceSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-actions-source.json');
+const editWithRemoteActionsSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-remote-actions.yml');
+const editWithRemoteActionsSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-remote-actions.json');
 const newSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/new.yml');
 const newSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/new.json');
 const dashboardSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/dashboard.yml');
@@ -84,6 +92,10 @@ describe('Test validation functions', () => {
 
 		const browseSchema = JSON.parse(browseSchemaJson.toString());
 		const editSchema = ymljs.parse(editSchemaYml.toString());
+		const editWithActionsSchema = ymljs.parse(editWithActionsSchemaYml.toString());
+		const editWithActionsStaticSchema = ymljs.parse(editWithActionsStaticSchemaYml.toString());
+		const editWithActionsSourceSchema = ymljs.parse(editWithActionsSourceSchemaYml.toString());
+		const editWithRemoteActionsSchema = ymljs.parse(editWithRemoteActionsSchemaYml.toString());
 		const newSchema = ymljs.parse(newSchemaYml.toString());
 
 		const dashboardSchema = ymljs.parse(dashboardSchemaYml.toString());
@@ -93,6 +105,10 @@ describe('Test validation functions', () => {
 
 		const browseData = Validator.execute(browseSchema, true, '/test/data1.json');
 		const editData = Validator.execute(editSchema, true, '/test/data2.json');
+		const editWithActionsData = Validator.execute(editWithActionsSchema, true, '/test/data7.json');
+		const editWithActionsStaticData = Validator.execute(editWithActionsStaticSchema, true, '/test/data8.json');
+		const editWithActionsSourceData = Validator.execute(editWithActionsSourceSchema, true, '/test/data9.json');
+		const editWithRemoteActionsData = Validator.execute(editWithRemoteActionsSchema, true, '/test/data10.json');
 		const newData = Validator.execute(newSchema, true, '/test/data6.json');
 		const dashboardData = Validator.execute(dashboardSchema, true, '/test/data3.json');
 		const previewData = Validator.execute(previewSchema, true, '/test/data4.json');
@@ -101,6 +117,10 @@ describe('Test validation functions', () => {
 
 		sinon.assert.match(browseData, JSON.parse(browseSchemaExpectedJson.toString()));
 		sinon.assert.match(editData, JSON.parse(editSchemaExpectedJson.toString()));
+		sinon.assert.match(editWithActionsData, JSON.parse(editWithActionsSchemaExpectedJson.toString()));
+		sinon.assert.match(editWithActionsStaticData, JSON.parse(editWithActionsStaticSchemaExpectedJson.toString()));
+		sinon.assert.match(editWithActionsSourceData, JSON.parse(editWithActionsSourceSchemaExpectedJson.toString()));
+		sinon.assert.match(editWithRemoteActionsData, JSON.parse(editWithRemoteActionsSchemaExpectedJson.toString()));
 		sinon.assert.match(newData, JSON.parse(newSchemaExpectedJson.toString()));
 		sinon.assert.match(dashboardData, JSON.parse(dashboardSchemaExpectedJson.toString()));
 		sinon.assert.match(previewData, JSON.parse(previewSchemaExpected.toString()));


### PR DESCRIPTION
… remoteActions no ambos

## Link al ticket
- [Link](https://janiscommerce.atlassian.net/browse/JMV-2958)
## Descripción del requerimiento
- Se necesita crear una nueva prop Actions que reemplace pero no elimine las RemoteActions. 
## Descripción de la solución
- Se agrego un nuevo schema para **Actions** que reutiliza la logica de **massiveActions** para que tome tanto valores **static** como **remote** los cuales llegan asi: static; **StaticActions**, remote; **Source**. 
- Se agrego validacion para que sea requerido uno de estos dos tipos ya sea **static** o **remote** para esto se utilizo **anyOf** que valida que cualquiera de las dos properties sean requeridas pudiendo ser 1 de las 2 o ambas. 
- Se extrajo el schema de **remoteActions** en un archivo nuevo para poder reutilizarlo en el condicional agregado, dichos condicional valida si existe **actions** y cuando es asi impide que se reciba **remoteActions** y viceversa para que de esta forma solo uno de los dos sea aceptado, en ningun caso ambos. Se agrego mocks de prueba con **actions** para los casos de uso: ambos tipos, solo **static** y solo **remote** y mock para **remoteActions** para poder probarlo por separado. Se utilizo **allOf** para que siempre deban cumplirse los dos condicionales. 
## Cómo se puede probar?
- Ejecutando los siguientes comandos para probar cada de uso de actions y remoteActions:
  Edit con RemoteActions -  node index.js validate -i tests/mocks/schemas/edit-with-remote-actions.yml
  Edit con Actions -  node index.js validate -i tests/mocks/schemas/edit-with-actions.yml
  Edit con Actions solo con Source -  node index.js validate -i tests/mocks/schemas/edit-with-actions-source.yml
  Edit con Actions solo con StaticActions -  node index.js validate -i tests/mocks/schemas/edit-with-actions-static.yml
Se puede agregar ya sea al test del RemoteActions o de Actions para validar que cuando van juntos explota el test, lo mismo para Source y StaticActions
## Link a la documentación
- 
## Datos extra a tener en cuenta
- 
## Changelog
``` Agregado actions al schema de Edit, validando que solo pueda estar actions o remoteActions, siendo excluyente el uno del otro.  
### Added
- Agregado actions al schema de Edit
- Validado que solo pueda tenerse actions o remoteActions en schema de Edit, en ningun caso ambos, siendo ambos opcionales.
- Validado que actions deba tener al menos una de estas propiedades: staticActions o source, pudiendo estar ambos presentes tambien.
- Creado archivo para schema remoteActions
- Creado archivo para schema actions
- Agregados test para diferentes casos de uso de Edits los cuales son: Edit con actions, Edit con remoteActions, Edit con actions que tengan solo source, Edit con actions que tengan solo staticActions
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
