### PR TITLE
Removido warning de deprecacion de remoteActions

### DIFF
--- a/lib/deprecation-validators/index.js
+++ b/lib/deprecation-validators/index.js
@@ -4,12 +4,12 @@ const title = require('./title-deprecation');
 const titleComponents = require('./title-components-deprecation');
 const staticFilters = require('./static-filters-deprecation');
 const pathQuery = require('./path-query-deprecation');
-const remoteAction = require('./remoteActions-deprecation');
+// const remoteAction = require('./remoteActions-deprecation');
 
 module.exports = {
 	title,
 	titleComponents,
 	staticFilters,
-	pathQuery,
-	remoteAction
+	pathQuery
+	// remoteAction
 };


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/jira/software/c/projects/JMV/boards/445?modal=detail&assignee=63da4463c2b1cb6b3470270d
## Descripción del requerimiento
Remover el mensaje de deprecacion de remoteActions
## Descripción de la solución
Se comento el import que accede al archivo que contiene la funcion validadora y que genera el warning de deprecation
## Cómo se puede probar?
Ejecutando el siguiente comando para verificar que no se muestra el warning
`node index.js validate -i tests/mocks/schemas/edit-with-remote-actions.yml `
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```Se desactivo el warning de depracacion de remoteActions
### Added
- 
### Changed
- Se desactivo el warning de depracacion de remoteActions
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
