### PR TITLE
add marker prop: hideDefaultMarkers

### DIFF
--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1

--- a/lib/schemas/edit-new/modules/components/map.js
+++ b/lib/schemas/edit-new/modules/components/map.js
@@ -35,6 +35,7 @@ const markersSchema = {
 		icon: { type: 'string' },
 		color: { type: 'string' },
 		size: { type: 'number' },
+		hideDefaultMarkers: { type: 'boolean' },
 		useTheme: { type: ['boolean', 'string'] },
 		themeConditionals,
 		themeField: { type: 'string' },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -655,6 +655,7 @@ sections:
                 size: 30
                 useTheme: themeName
                 themeField: themeField
+                hideDefaultMarkers: true
                 infoSchema:
                   fieldsGroup:
                     - name: detail

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1030,6 +1030,7 @@
 									"size": 30,
 									"useTheme": "themeName",
 									"themeField": "themeField",
+									"hideDefaultMarkers": true,
 									"infoSchema": {
 										"fieldsGroup": [
 											{


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3070

## Descripción del requerimiento
Contexto
En el detalle de una ruta, estamos mostrando un mapa con el recorrido hecho por el driver donde se entregaron los distintos pedidos. Esto es gracias a la App de delivery donde se hizo un desarrollo donde le enviamos el recorrido del chofer cada X tiempo para despues dibujar todo el recorrido. Janis guarda esta informacion para luego mostrarla en el mapa.

El problema es que en cada latitud y longitud que se usa para dibujar todo el camino recorrido, se esta mostrando un marcador que no brinda ninguna funcionalidad y al contrario, esta molestando.

Necesidad
Poder mostrar solamente un marcador para el punto de origen y otro para el de destino.

## Descripción de la solución
Se agrego la prop `hideDefaultMarkers` al componente `map.js` y a los test `edit.yml` y `expected/edit.json` para poder probarlos.

## Cómo se puede probar?
- npm t
- node index.js validate -i tests/mocks/schemas/edit.yml 
- node index.js validate -i tests/mocks/schemas/expected/edit.json 

