### PR TITLE
Agregado min max fields estaticos y dinamicos a input

### DIFF
--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -26,10 +26,32 @@ module.exports = makeComponent({
 				},
 				then: {
 					not: {
-						properties: {
-							minValue: { type: 'number' }
-						},
-						required: ['minValue']
+						anyOf: [
+							{
+								properties: {
+									minValue: { type: 'number' }
+								},
+								required: ['minValue']
+							},
+							{
+								properties: {
+									maxValue: { type: 'number' }
+								},
+								required: ['maxValue']
+							},
+							{
+								properties: {
+									minValueField: { type: 'string' }
+								},
+								required: ['minValueField']
+							},
+							{
+								properties: {
+									maxValueField: { type: 'string' }
+								},
+								required: ['maxValueField']
+							}
+						]
 					}
 				}
 			},
@@ -41,106 +63,32 @@ module.exports = makeComponent({
 				},
 				then: {
 					not: {
-						properties: {
-							minValue: { type: 'number' }
-						},
-						required: ['minValue']
-					}
-				}
-			},
-			{
-				if: {
-					not: {
-						properties: {
-							type: { const: 'number' }
-						}
-					}
-				},
-				then: {
-					not: {
-						properties: {
-							maxValue: { type: 'number' }
-						},
-						required: ['maxValue']
-					}
-				}
-			},
-			{
-				if: {
-					properties: {
-						type: { const: false }
-					}
-				},
-				then: {
-					not: {
-						properties: {
-							maxValue: { type: 'number' }
-						},
-						required: ['maxValue']
-					}
-				}
-			},
-			{
-				if: {
-					not: {
-						properties: {
-							type: { const: 'number' }
-						}
-					}
-				},
-				then: {
-					not: {
-						properties: {
-							minValueField: { type: 'string' }
-						},
-						required: ['minValueField']
-					}
-				}
-			},
-			{
-				if: {
-					properties: {
-						type: { const: false }
-					}
-				},
-				then: {
-					not: {
-						properties: {
-							minValueField: { type: 'string' }
-						},
-						required: ['minValueField']
-					}
-				}
-			},
-			{
-				if: {
-					not: {
-						properties: {
-							type: { const: 'number' }
-						}
-					}
-				},
-				then: {
-					not: {
-						properties: {
-							maxValueField: { type: 'string' }
-						},
-						required: ['maxValueField']
-					}
-				}
-			},
-			{
-				if: {
-					properties: {
-						type: { const: false }
-					}
-				},
-				then: {
-					not: {
-						properties: {
-							maxValueField: { type: 'string' }
-						},
-						required: ['maxValueField']
+						anyOf: [
+							{
+								properties: {
+									minValue: { type: 'number' }
+								},
+								required: ['minValue']
+							},
+							{
+								properties: {
+									maxValue: { type: 'number' }
+								},
+								required: ['maxValue']
+							},
+							{
+								properties: {
+									minValueField: { type: 'string' }
+								},
+								required: ['minValueField']
+							},
+							{
+								properties: {
+									maxValueField: { type: 'string' }
+								},
+								required: ['maxValueField']
+							}
+						]
 					}
 				}
 			},

--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -18,48 +18,18 @@ module.exports = makeComponent({
 		allOf: [
 			{
 				if: {
-					not: {
-						properties: {
-							type: { const: 'number' }
-						}
-					}
-				},
-				then: {
-					not: {
-						anyOf: [
-							{
-								properties: {
-									minValue: { type: 'number' }
-								},
-								required: ['minValue']
-							},
-							{
-								properties: {
-									maxValue: { type: 'number' }
-								},
-								required: ['maxValue']
-							},
-							{
-								properties: {
-									minValueField: { type: 'string' }
-								},
-								required: ['minValueField']
-							},
-							{
-								properties: {
-									maxValueField: { type: 'string' }
-								},
-								required: ['maxValueField']
+					anyOf: [{
+						not: {
+							properties: {
+								type: { const: 'number' }
 							}
-						]
-					}
-				}
-			},
-			{
-				if: {
-					properties: {
-						type: { const: false }
-					}
+						}
+					},
+					{
+						properties: {
+							type: { const: false }
+						}
+					}]
 				},
 				then: {
 					not: {

--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -8,6 +8,48 @@ module.exports = makeComponent({
 	properties: {
 		icon: { type: 'string' },
 		type: { enum: ['text', 'number', 'email', 'password', 'hidden'] },
-		autoComplete: { type: 'boolean' }
+		autoComplete: { type: 'boolean' },
+		minValue: { type: 'number' },
+		minValueField: { type: 'string' },
+		maxValue: { type: 'number' },
+		maxValueField: { type: 'string' } // entender bien esto y usar if para excluir
+	},
+	conditions: {
+		allOf: [
+			{
+				if: {
+					properties: { minValue: { const: false } }
+				},
+				then: {
+					not: {
+						properties: { minValue: { type: 'number' } },
+						required: ['minValue']
+					}
+				},
+				else: {
+					not: {
+						properties: { minValueField: { type: 'string' } },
+						required: ['minValueField']
+					}
+				}
+			},
+			{
+				if: {
+					properties: { maxValue: { const: false } }
+				},
+				then: {
+					not: {
+						properties: { maxValue: { type: 'number' } },
+						required: ['maxValue']
+					}
+				},
+				else: {
+					not: {
+						properties: { maxValueField: { type: 'string' } },
+						required: ['maxValueField']
+					}
+				}
+			}
+		]
 	}
 });

--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -12,7 +12,7 @@ module.exports = makeComponent({
 		minValue: { type: 'number' },
 		minValueField: { type: 'string' },
 		maxValue: { type: 'number' },
-		maxValueField: { type: 'string' } // entender bien esto y usar if para excluir
+		maxValueField: { type: 'string' }
 	},
 	conditions: {
 		allOf: [

--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -18,6 +18,74 @@ module.exports = makeComponent({
 		allOf: [
 			{
 				if: {
+					not: {
+						properties: {
+							type: { const: 'number' }
+						}
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							minValue: { type: 'number' }
+						},
+						required: ['minValue']
+					}
+				}
+			},
+			{
+				if: {
+					not: {
+						properties: {
+							type: { const: 'number' }
+						}
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							maxValue: { type: 'number' }
+						},
+						required: ['maxValue']
+					}
+				}
+			},
+			{
+				if: {
+					not: {
+						properties: {
+							type: { const: 'number' }
+						}
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							minValueField: { type: 'string' }
+						},
+						required: ['minValueField']
+					}
+				}
+			},
+			{
+				if: {
+					not: {
+						properties: {
+							type: { const: 'number' }
+						}
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							maxValueField: { type: 'string' }
+						},
+						required: ['maxValueField']
+					}
+				}
+			},
+			{
+				if: {
 					properties: { minValue: { const: false } }
 				},
 				then: {

--- a/lib/schemas/edit-new/modules/components/input.js
+++ b/lib/schemas/edit-new/modules/components/input.js
@@ -35,10 +35,40 @@ module.exports = makeComponent({
 			},
 			{
 				if: {
+					properties: {
+						type: { const: false }
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							minValue: { type: 'number' }
+						},
+						required: ['minValue']
+					}
+				}
+			},
+			{
+				if: {
 					not: {
 						properties: {
 							type: { const: 'number' }
 						}
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							maxValue: { type: 'number' }
+						},
+						required: ['maxValue']
+					}
+				}
+			},
+			{
+				if: {
+					properties: {
+						type: { const: false }
 					}
 				},
 				then: {
@@ -69,10 +99,40 @@ module.exports = makeComponent({
 			},
 			{
 				if: {
+					properties: {
+						type: { const: false }
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							minValueField: { type: 'string' }
+						},
+						required: ['minValueField']
+					}
+				}
+			},
+			{
+				if: {
 					not: {
 						properties: {
 							type: { const: 'number' }
 						}
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							maxValueField: { type: 'string' }
+						},
+						required: ['maxValueField']
+					}
+				}
+			},
+			{
+				if: {
+					properties: {
+						type: { const: false }
 					}
 				},
 				then: {

--- a/tests/mocks/schemas/edit-with-min-max-input.yml
+++ b/tests/mocks/schemas/edit-with-min-max-input.yml
@@ -1,0 +1,54 @@
+service: sac
+name: claim-type-edit
+root: Edit
+source:
+  service: sac
+  namespace: claim-type
+  method: get
+sections:
+- name: mainFormSection
+  rootComponent: MainForm
+  fieldsGroup:
+  - name: detail
+    icon: catalogue
+    fields:
+    - name: name
+      component: Input
+      validations:
+      - - name: required
+      - - name: maxLength
+          options:
+            length: 50
+      componentAttributes:
+        minValue: 5
+        maxValue: 5
+    - name: name2
+      component: Input
+      validations:
+      - - name: required
+      - - name: maxLength
+          options:
+            length: 50
+      componentAttributes:
+        minValueField: '5'
+        maxValueField: '5'
+    - name: name3
+      component: Input
+      validations:
+      - - name: required
+      - - name: maxLength
+          options:
+            length: 50
+      componentAttributes:
+        minValue: 5
+        maxValueField: '5'
+    - name: name4
+      component: Input
+      validations:
+      - - name: required
+      - - name: maxLength
+          options:
+            length: 50
+      componentAttributes:
+        minValueField: '5'
+        maxValue: 5

--- a/tests/mocks/schemas/edit-with-min-max-input.yml
+++ b/tests/mocks/schemas/edit-with-min-max-input.yml
@@ -20,6 +20,7 @@ sections:
           options:
             length: 50
       componentAttributes:
+        type: 'number'
         minValue: 5
         maxValue: 5
     - name: name2
@@ -30,6 +31,7 @@ sections:
           options:
             length: 50
       componentAttributes:
+        type: 'number'
         minValueField: '5'
         maxValueField: '5'
     - name: name3
@@ -40,6 +42,7 @@ sections:
           options:
             length: 50
       componentAttributes:
+        type: 'number'
         minValue: 5
         maxValueField: '5'
     - name: name4
@@ -50,5 +53,15 @@ sections:
           options:
             length: 50
       componentAttributes:
+        type: 'number'
         minValueField: '5'
         maxValue: 5
+    - name: name5
+      component: Input
+      validations:
+      - - name: required
+      - - name: maxLength
+          options:
+            length: 50
+      componentAttributes:
+        type: 'text'

--- a/tests/mocks/schemas/expected/edit-with-min-max-input.json
+++ b/tests/mocks/schemas/expected/edit-with-min-max-input.json
@@ -1,0 +1,116 @@
+{
+    "service": "sac",
+    "name": "claim-type-edit",
+    "root": "Edit",
+    "source": {
+        "service": "sac",
+        "namespace": "claim-type",
+        "method": "get"
+    },
+    "sections": [
+        {
+            "name": "mainFormSection",
+            "rootComponent": "MainForm",
+            "fieldsGroup": [
+                {
+                    "name": "detail",
+                    "icon": "catalogue",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "component": "Input",
+                            "validations": [
+                                [
+                                    {
+                                        "name": "required"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "name": "maxLength",
+                                        "options": {
+                                            "length": 50
+                                        }
+                                    }
+                                ]
+                            ],
+                            "componentAttributes": {
+                                "minValue": 5,
+                                "maxValue": 5
+                            }
+                        },
+                        {
+                            "name": "name2",
+                            "component": "Input",
+                            "validations": [
+                                [
+                                    {
+                                        "name": "required"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "name": "maxLength",
+                                        "options": {
+                                            "length": 50
+                                        }
+                                    }
+                                ]
+                            ],
+                            "componentAttributes": {
+                                "minValueField": "5",
+                                "maxValueField": "5"
+                            }
+                        },
+                        {
+                            "name": "name3",
+                            "component": "Input",
+                            "validations": [
+                                [
+                                    {
+                                        "name": "required"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "name": "maxLength",
+                                        "options": {
+                                            "length": 50
+                                        }
+                                    }
+                                ]
+                            ],
+                            "componentAttributes": {
+                                "minValue": 5,
+                                "maxValueField": "5"
+                            }
+                        },
+                        {
+                            "name": "name4",
+                            "component": "Input",
+                            "validations": [
+                                [
+                                    {
+                                        "name": "required"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "name": "maxLength",
+                                        "options": {
+                                            "length": 50
+                                        }
+                                    }
+                                ]
+                            ],
+                            "componentAttributes": {
+                                "minValueField": "5",
+                                "maxValue": 5
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/mocks/schemas/expected/edit-with-min-max-input.json
+++ b/tests/mocks/schemas/expected/edit-with-min-max-input.json
@@ -35,6 +35,7 @@
                                 ]
                             ],
                             "componentAttributes": {
+                                "type": "number",
                                 "minValue": 5,
                                 "maxValue": 5
                             }
@@ -58,6 +59,7 @@
                                 ]
                             ],
                             "componentAttributes": {
+                                "type": "number",
                                 "minValueField": "5",
                                 "maxValueField": "5"
                             }
@@ -81,6 +83,7 @@
                                 ]
                             ],
                             "componentAttributes": {
+                                "type": "number",
                                 "minValue": 5,
                                 "maxValueField": "5"
                             }
@@ -104,8 +107,31 @@
                                 ]
                             ],
                             "componentAttributes": {
+                                "type": "number",
                                 "minValueField": "5",
                                 "maxValue": 5
+                            }
+                        },
+                        {
+                            "name": "name5",
+                            "component": "Input",
+                            "validations": [
+                                [
+                                    {
+                                        "name": "required"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "name": "maxLength",
+                                        "options": {
+                                            "length": 50
+                                        }
+                                    }
+                                ]
+                            ],
+                            "componentAttributes": {
+                                "type": "text"
                             }
                         }
                     ]

--- a/tests/mocks/schemas/new-with-min-max-input.yml
+++ b/tests/mocks/schemas/new-with-min-max-input.yml
@@ -1,0 +1,27 @@
+service: sac
+name: claim-motive-new
+root: Create
+canCreate: false
+target:
+  service: sac
+  namespace: claim-motive
+  method: save
+saveRedirectUrl: /some-path
+cancelRedirectUrl: /some-path
+sections:
+- name: mainFormSection
+  rootComponent: MainForm
+  fieldsGroup:
+  - name: detail
+    icon: catalogue
+    fields:
+    - name: name
+      component: Input
+      validations:
+        - - name: required
+        - - name: maxLength
+            options:
+              length: 50
+      componentAttributes:
+        minValueField: '5'
+        maxValue: 5

--- a/tests/mocks/schemas/new-with-min-max-input.yml
+++ b/tests/mocks/schemas/new-with-min-max-input.yml
@@ -23,5 +23,6 @@ sections:
             options:
               length: 50
       componentAttributes:
+        type: 'number'
         minValueField: '5'
         maxValue: 5

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -18,9 +18,12 @@ const editWithActionsStaticSchemaYml = fs.readFileSync(process.cwd() + '/tests/m
 const editWithActionsStaticSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-actions-static.json');
 const editWithActionsSourceSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-actions-source.yml');
 const editWithActionsSourceSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-actions-source.json');
+const editWithMinMaxInputSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-min-max-input.yml');
+const editWithMinMaxInputSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-min-max-input.json');
 const editWithRemoteActionsSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-remote-actions.yml');
 const editWithRemoteActionsSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-remote-actions.json');
 const newSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/new.yml');
+const newWithMinMaxInputSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/new-with-min-max-input.yml');
 const newSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/new.json');
 const dashboardSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/dashboard.yml');
 const dashboardSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/dashboard.json');
@@ -98,8 +101,10 @@ describe('Test validation functions', () => {
 		const editWithActionsSchema = ymljs.parse(editWithActionsSchemaYml.toString());
 		const editWithActionsStaticSchema = ymljs.parse(editWithActionsStaticSchemaYml.toString());
 		const editWithActionsSourceSchema = ymljs.parse(editWithActionsSourceSchemaYml.toString());
+		const editWithMinMaxInputSchema = ymljs.parse(editWithMinMaxInputSchemaYml.toString());
 		const editWithRemoteActionsSchema = ymljs.parse(editWithRemoteActionsSchemaYml.toString());
 		const newSchema = ymljs.parse(newSchemaYml.toString());
+		const newWithMinMaxInputSchema = ymljs.parse(newWithMinMaxInputSchemaYml.toString());
 
 		const dashboardSchema = ymljs.parse(dashboardSchemaYml.toString());
 		const previewSchema = ymljs.parse(previewSchemaYml.toString());
@@ -113,7 +118,9 @@ describe('Test validation functions', () => {
 		const editWithActionsStaticData = Validator.execute(editWithActionsStaticSchema, true, '/test/data8.json');
 		const editWithActionsSourceData = Validator.execute(editWithActionsSourceSchema, true, '/test/data9.json');
 		const editWithRemoteActionsData = Validator.execute(editWithRemoteActionsSchema, true, '/test/data10.json');
+		const editWithMinMaxInputData = Validator.execute(editWithMinMaxInputSchema, true, '/test/data11.json');
 		const newData = Validator.execute(newSchema, true, '/test/data6.json');
+		const newWithMinMaxInputData = Validator.execute(newWithMinMaxInputSchema, true, '/test/data12.json');
 		const dashboardData = Validator.execute(dashboardSchema, true, '/test/data3.json');
 		const previewData = Validator.execute(previewSchema, true, '/test/data4.json');
 		const sectionData = Validator.execute(sectionSchema, true, '/test/data5.json');
@@ -125,8 +132,10 @@ describe('Test validation functions', () => {
 		sinon.assert.match(editWithActionsData, JSON.parse(editWithActionsSchemaExpectedJson.toString()));
 		sinon.assert.match(editWithActionsStaticData, JSON.parse(editWithActionsStaticSchemaExpectedJson.toString()));
 		sinon.assert.match(editWithActionsSourceData, JSON.parse(editWithActionsSourceSchemaExpectedJson.toString()));
+		sinon.assert.match(editWithMinMaxInputData, JSON.parse(editWithMinMaxInputSchemaExpectedJson.toString()));
 		sinon.assert.match(editWithRemoteActionsData, JSON.parse(editWithRemoteActionsSchemaExpectedJson.toString()));
 		sinon.assert.match(newData, JSON.parse(newSchemaExpectedJson.toString()));
+		sinon.assert.match(newWithMinMaxInputData, JSON.parse(newSchemaExpectedJson.toString()));
 		sinon.assert.match(dashboardData, JSON.parse(dashboardSchemaExpectedJson.toString()));
 		sinon.assert.match(previewData, JSON.parse(previewSchemaExpected.toString()));
 		sinon.assert.match(sectionData, JSON.parse(sectionExampleExpected.toString()));


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3060
## Descripción del requerimiento
Se requiere agregar las props minValue, minValueField, maxValue y maxValueField a los componentAttributes de Input para poder utilizarlo en todo views, se debe condicionar que solo se pueda agregar minValue o minValueField y solo maxValue o maxValueField, tambien debe permitirse no incluir ninguna de las 4.
## Descripción de la solución
Se agregaron properties al schema de componentAttributes de Input atraves de makeComponent, tambien se le paso a makeComponent condicionales que limitan el uso del valor estatico y dinamico dejando usar solo uno para min y solo uno para max, se agregaron casos de prueba para probar la funcionalidad nueva en edit y new.
Se agregaron tambien condicionales para limitar que solo se pueda usar cualquiera de las props nuevas cuando type sea number
## Cómo se puede probar?
Accediendo a la rama y ejecutando npm run test para verificar que los test pasan correctamente, tambien se puede intentar agregar minValue y minValueField al mismo tiempo para verificar que rompe, lo mismo con max.
Cambiando el type a text para que rompan los tests, o quitando la prop type donde tambien deben romper los test
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
``` 
- Agregadas properties minValue, minValueField, maxValue y maxValueField a componentAttributes de Input condicionadas para solo poder mostrar  minValue o minValueField y maxValue o maxValueField
- Agregados casos de prueba para minValue, minValueField, maxValue y maxValueField tanto en edit como new
- Agregada validacion para no permitir ingresar las keys nuevas cuando no exista la key type o cuando sea su valor diferente a number
### Added
- Agregadas properties minValue, minValueField, maxValue y maxValueField a componentAttributes de Input condicionadas para solo poder mostrar  minValue o minValueField y maxValue o maxValueField
- Agregados casos de prueba para minValue, minValueField, maxValue y maxValueField tanto en edit como new
- Agregada validacion para no permitir ingresar las keys nuevas cuando no exista la key type o cuando sea su valor diferente a number
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
