### PR TITLE
add addStaticValue mapper

### DIFF
--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -163,6 +163,29 @@ const baseMapperSchema = [
 		if: {
 			type: 'object',
 			properties: {
+				name: { const: 'addStaticValue' }
+			}
+		},
+		then: {
+			properties: {
+				name: { const: 'addStaticValue' },
+				props: {
+					type: 'object',
+					properties: {
+						value: { type: 'string' },
+						translate: { type: 'boolean' }
+					},
+					required: ['value'],
+					additionalProperties: false
+				}
+			},
+			required: ['props', 'name']
+		}
+	},
+	{
+		if: {
+			type: 'object',
+			properties: {
 				name: { enum: MAPPERS }
 			}
 		},

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -445,6 +445,14 @@ sections:
               iconColor: colorName
               fontWeight: normal
 
+          - name: exampleStaticValueMapper
+            component: Text
+            mapper:
+              name: addStaticValue
+              props:
+                value: common.action.viewMore
+                translate: true
+
           - name: exampleImage
             translateLabel: false
             component: Image

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -710,6 +710,18 @@
 							}
 						},
 						{
+							"name": "exampleStaticValueMapper",
+							"component": "Text",
+							"componentAttributes": {},
+							"mapper": {
+								"name": "addStaticValue",
+								"props": {
+									"value": "common.action.viewMore",
+                					"translate": true
+								}
+							}
+						},
+						{
 							"name": "exampleImage",
 							"component": "Image",
 							"translateLabel": false,


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3082
https://janiscommerce.atlassian.net/browse/JMV-3084
## Descripción del requerimiento
Se debe agregar un nuevo mapper para poder setear valores estáticos en un campo readOnly, donde tenga la posibilidad de traducirlo.

_**Analisis funcional**_

Agregar un mapper nuevo addStaticValue, donde podamos mandarle por props un value(string) y una property que indique sise traduce o no(Boolean).
El campo que tenga este mapper, solo va mostrar el valor que este genere.
## Descripción de la solución
 Se agregó el nuevo mapper addStaticValue con las properties descritas en el requerimiento
## Cómo se puede probar?
- Accediendo a la rama y ejecutando npm run test para verificar que los test pasan correctamente, tambien probando las properties del nuevo mapper en un schema.
## Link a la documentación
- https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2219671665/Mappers#addStaticValue
## Changelog
```
### Added
- Add addStaticValue mapper to show custom values in fields
```