### PR TITLE
Agregada key openPrint componentAttributes a Link

### DIFF
--- a/lib/schemas/common-components/link.js
+++ b/lib/schemas/common-components/link.js
@@ -15,6 +15,7 @@ module.exports = makeComponent({
 		target: { type: 'string' },
 		path: { type: 'string' },
 		urlTarget: { $ref: 'schemaDefinitions#/definitions/endpoint' },
-		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
+		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
+		openPrint: { type: 'boolean' }
 	}
 });

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -91,6 +91,13 @@
 				}
 			},
 			{
+				"name": "printLink",
+				"component": "Link",
+				"componentAttributes": {
+					"openPrint": true
+				}
+			},
+			{
 				"name": "status",
 				"component": "StatusChip",
 				"componentAttributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -126,6 +126,19 @@
 				}
 			},
 			{
+				"name": "printLink",
+				"component": "Link",
+				"attributes": {
+					"sortable": false,
+					"isDefaultSort": false,
+					"isStatus": false,
+					"initialSortDirection": "desc"
+				},
+				"componentAttributes": {
+					"openPrint": true
+				}
+			},
+			{
 				"name": "status",
 				"component": "StatusChip",
 				"attributes": {


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3121
## Descripción del requerimiento
Se requiere agregar la key openPrint a los componentAttributes de Link para poder indicar a views que el Link abrira una tab y un dialogo de impresion
## Descripción de la solución
Se agrego la key openPrint a los componentAttributes de Link
Se agrego un caso de prueba con la key nueva en browse
## Cómo se puede probar?
Ingresando a la rama y corriendo `npm run test` para probar que no rompa, se puede agregar la key en otros componente Link y no debe romper
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```Agregada key openPrint en componentAttributes de Link
Agregado caso de prueba con la key nueva en browse
### Added
- Agregada key openPrint en componentAttributes de Link
- Agregado caso de prueba con la key nueva en browse
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
