### PR TITLE
Agregada prop parentFilterDefaultValue

### DIFF
--- a/lib/schemas/edit-new/modules/components/selectMultilevel.js
+++ b/lib/schemas/edit-new/modules/components/selectMultilevel.js
@@ -12,6 +12,7 @@ module.exports = makeComponent({
 		translateLabels: { type: 'boolean' },
 		maxLevel: { type: 'number' },
 		parentFilterName: { type: 'string' },
+		parentFilterDefaultValue: { type: ['string', 'number', 'boolean'] },
 		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },

--- a/tests/mocks/schemas/edit-with-actions-source.yml
+++ b/tests/mocks/schemas/edit-with-actions-source.yml
@@ -1074,6 +1074,7 @@ sections:
             componentAttributes:
               translateLabels: true
               parentFilterName: parent
+              parentFilterDefaultValue: 'null'
               canClear: true
               maxLevel: 3
               options:

--- a/tests/mocks/schemas/expected/edit-with-actions-source.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-source.json
@@ -1681,6 +1681,7 @@
 							"componentAttributes": {
 								"translateLabels": true,
 								"parentFilterName": "parent",
+								"parentFilterDefaultValue": "null",
 								"canClear": true,
 								"maxLevel": 3,
 								"options": {


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3152
## Descripción del requerimiento
Se requiere agregar la prop `parentFilterDefaultValue` para poder agregar un valor por defecto por el cual se filtraran `SelectMultiLevel` cuando no aun no se haya seleccionando ningun valor. Dicho valor puede ser string, number o boolean ya que debe poder ser definido como lo requiera back
## Descripción de la solución
Se agrego la prop `parentFilterDefaultValue` al validador de `SelectMultiLevel` y se agrego la prop a tests para comprobar su funcionamiento
## Cómo se puede probar?
Ejecutando el comando npm run test y validando que no rompa nada. Se puede quitar la prop y tanto del yml como del json para comprobar que es una prop opcional. Tambien debe poder recibir valores string, number y boolean
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```Agregada prop `parentFilterDefaultValue` al validador de `SelectMultiLevel`
### Added
- Agregada prop `parentFilterDefaultValue` al validador de `SelectMultiLevel`
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
