### PR TITLE
Agregada prop showMissingProducts a orderItemsSection

### DIFF
--- a/lib/schemas/common-sections/sections/orderItemsSection.js
+++ b/lib/schemas/common-sections/sections/orderItemsSection.js
@@ -20,6 +20,7 @@ module.exports = {
 			showPurchasedItems: { type: 'boolean' },
 			showPickedItems: { type: 'boolean' },
 			showClaimItems: { type: 'boolean' },
+			showMissingProducts: { type: 'boolean' },
 			canEditPrice: { type: 'boolean' }
 		},
 		required: ['name', 'rootComponent'],

--- a/tests/mocks/schemas/edit-with-actions-source.yml
+++ b/tests/mocks/schemas/edit-with-actions-source.yml
@@ -1558,6 +1558,7 @@ sections:
     showPurchasedItems: false
     showPickedItems: true
     showClaimItems: false
+    showMissingProducts: false
     canEditPrice: true
 
   - name: anotherOrderItemsSection

--- a/tests/mocks/schemas/edit-with-actions-static.yml
+++ b/tests/mocks/schemas/edit-with-actions-static.yml
@@ -1563,6 +1563,7 @@ sections:
     showPurchasedItems: false
     showPickedItems: true
     showClaimItems: false
+    showMissingProducts: true
     canEditPrice: true
 
   - name: anotherOrderItemsSection

--- a/tests/mocks/schemas/edit-with-remote-actions.yml
+++ b/tests/mocks/schemas/edit-with-remote-actions.yml
@@ -1562,6 +1562,7 @@ sections:
     showPurchasedItems: false
     showPickedItems: true
     showClaimItems: false
+    showMissingProducts: true
     canEditPrice: true
 
   - name: anotherOrderItemsSection

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1565,6 +1565,7 @@ sections:
     showPurchasedItems: false
     showPickedItems: true
     showClaimItems: false
+    showMissingProducts: true
     canEditPrice: true
 
   - name: anotherOrderItemsSection

--- a/tests/mocks/schemas/expected/edit-with-actions-source.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-source.json
@@ -2448,6 +2448,7 @@
 			"showPurchasedItems": false,
 			"showPickedItems": true,
 			"showClaimItems": false,
+			"showMissingProducts": false,
 			"canEditPrice": true
 		},
 		{

--- a/tests/mocks/schemas/expected/edit-with-actions-static.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-static.json
@@ -2457,6 +2457,7 @@
 			"showPurchasedItems": false,
 			"showPickedItems": true,
 			"showClaimItems": false,
+			"showMissingProducts": true,
 			"canEditPrice": true
 		},
 		{

--- a/tests/mocks/schemas/expected/edit-with-remote-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-remote-actions.json
@@ -2455,6 +2455,7 @@
 			"showPurchasedItems": false,
 			"showPickedItems": true,
 			"showClaimItems": false,
+			"showMissingProducts": true,
 			"canEditPrice": true
 		},
 		{

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -2458,6 +2458,7 @@
 			"showPurchasedItems": false,
 			"showPickedItems": true,
 			"showClaimItems": false,
+			"showMissingProducts": true,
 			"canEditPrice": true
 		},
 		{


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-2968
## Descripción del requerimiento
Se requiere agregar una prop nueva a OrderItemsSection para controlar si se muestran o no los missing products
## Descripción de la solución
Se agrego la prop showMissingProducts al schema de OrderItemsSection
Se agregaron usos de la prop nueva en diferentes casos de uso para probar que funcione correctamente, se dejo algunos sin la prop, en otros se la seteo con true y otras con false para probar todos los casos
## Cómo se puede probar?
Entrando a la rama y ejecutando npm run test y verificando que pasen todos los test, se puede probar cambiando a false, true o retirar la prop y en todos los casos no debe romper
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```Se agrego la prop showMissingProducts a OrderItemsSection
Se actualizaron los test para incluir la prop nueva
### Added
- Se agrego la prop showMissingProducts a OrderItemsSection
### Changed
- Se actualizaron los test para incluir la prop nueva
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
