### PR TITLE
change type to boolean

### DIFF
--- a/lib/schemas/edit-new/modules/components/map.js
+++ b/lib/schemas/edit-new/modules/components/map.js
@@ -61,8 +61,7 @@ module.exports.mapSchema = makeComponent({
 		originMarker: {
 			oneOf: [
 				{
-					type: 'string',
-					enum: ['default']
+					type: 'boolean'
 				},
 				{
 					type: 'object',
@@ -78,8 +77,7 @@ module.exports.mapSchema = makeComponent({
 		destinationMarker: {
 			oneOf: [
 				{
-					type: 'string',
-					enum: ['default']
+					type: 'boolean'
 				},
 				{
 					type: 'object',

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -713,7 +713,7 @@ sections:
               showPOI: false
               maxMarkersQuantity: 5
               drawRoute: true
-              originMarker: "default" 
+              originMarker: true
               destinationMarker:
                 icon: janis
                 size: "24"

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1124,7 +1124,7 @@
 								"showPOI": false,
 								"maxMarkersQuantity": 5,
 								"drawRoute": true,
-								"originMarker": "default",
+								"originMarker": true,
 								"destinationMarker": {
 									"icon": "janis",
 									"size": "24",


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3210

## Descripción del requerimiento
Cambiar el validador y en vez de string, usar un bool pero eso solo te va a permitir usar el marcador por default.

## Descripción de la solución
Cambiamos la prop para que ya no acepte string, sino boolean. Para cuando se quiere usar el marcador por default. En caso de querer personalizarlo se seguira optando por el objeto con sus props.

## Cómo se puede probar?
- Correr los test.
- Verificar que las dos nuevas props solo acepten: boolean o un objeto con icono como requerido (size y color opcional).
- Sin icon el objeto, deberia romper.
- Si recibimos un string debería romper
- Si no enviamos las props no debería pasar nada, seguiría funcionando los test.
- Si recibimos el objeto con prop icon en las nuevas props, pasa tests

## Link a la documentación
https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2243166317/Map

## Datos extra a tener en cuenta
-
## Changelog
```
### Added
- 
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
