### PR TITLE
add endpointParameters to UserSelector

### DIFF
--- a/lib/schemas/browse/modules/filters/components/userSelector.js
+++ b/lib/schemas/browse/modules/filters/components/userSelector.js
@@ -10,6 +10,7 @@ module.exports = makeComponent({
 		onlyActiveUsers: { type: 'boolean' },
 		canClear: { type: 'boolean' },
 		showImage: { type: 'boolean' },
-		source: { $ref: 'schemaDefinitions#/definitions/endpoint' }
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
 	}
 });

--- a/lib/schemas/edit-new/modules/components/userSelector.js
+++ b/lib/schemas/edit-new/modules/components/userSelector.js
@@ -11,6 +11,7 @@ module.exports = makeComponent({
 		canCreate: { type: 'boolean' },
 		canClear: { type: 'boolean' },
 		showImage: { type: 'boolean' },
-		source: { $ref: 'schemaDefinitions#/definitions/endpoint' }
+		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
 	}
 });

--- a/tests/mocks/schemas/browse-columnSortableMatch.json
+++ b/tests/mocks/schemas/browse-columnSortableMatch.json
@@ -748,6 +748,36 @@
 			}
 		},
 		{
+			"name": "membersWithEndpointParameters",
+			"component": "UserSelector",
+			"componentAttributes": {
+				"isMulti": true,
+				"onlyActiveUsers": true,
+				"source": {
+					"service": "service",
+					"namespace": "namespace",
+					"method": "method",
+					"resolve": false
+				},
+				"endpointParameters": [
+					{
+						"name": "status",
+						"target": "path",
+						"value": {
+							"static": 2
+						}
+					},
+					{
+						"name": "status",
+						"target": "query",
+						"value": {
+							"static": 1
+						}
+					}
+				]
+			}
+		},
+		{
 			"name": "newStatusOne",
 			"component": "StatusSelector"
 		},

--- a/tests/mocks/schemas/expected/browse-columnSortableMatch.json
+++ b/tests/mocks/schemas/expected/browse-columnSortableMatch.json
@@ -802,6 +802,36 @@
 			}
 		},
 		{
+			"name": "membersWithEndpointParameters",
+			"component": "UserSelector",
+			"componentAttributes": {
+				"isMulti": true,
+				"onlyActiveUsers": true,
+				"source": {
+					"service": "service",
+					"namespace": "namespace",
+					"method": "method",
+					"resolve": false
+				},
+				"endpointParameters": [
+					{
+						"name": "status",
+						"target": "path",
+						"value": {
+							"static": 2
+						}
+					},
+					{
+						"name": "status",
+						"target": "query",
+						"value": {
+							"static": 1
+						}
+					}
+				]
+			}
+		},
+		{
 			"name": "newStatusOne",
 			"component": "StatusSelector",
 			"componentAttributes": {}


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3248

## Descripción del requerimiento
A raiz de ATR-1081: Listar en Ronda sólo Pickers asignados al warehouse
EN PROGRESO
 hoy lo que sucede con el UserSelector es que uno de los usos es para poder listar pickers. El problema es que como esta hecho, no acepta endpointParameters y se necesitan para poder agregar distintos filtros, uno de ellos seria el filtro nuevo de pickingpoint. Esto tiene una relacion con lo que se va a hacer en JMV-3247:

Necesidad
Que el componente User selector pueda aceptar endpointParameters

## Descripción de la solución
Se agrego la posibilidad de usar endpointParameters en el componente userSelector

## Cómo se puede probar?
Correr los test:
- Que funcionen con endpointParameters definidos.
- Que funcionen sin endpointParameters definidos.

## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```
### Added
- 
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
