### PR TITLE
add requestFields to actions type form

### DIFF
--- a/lib/schemas/common/generic-actions/action.js
+++ b/lib/schemas/common/generic-actions/action.js
@@ -59,7 +59,7 @@ module.exports = {
 						type: 'object',
 						properties: {
 							...commonAttrs,
-							requestFields: { type: 'object' },
+							requestFields: { type: 'object', minProperties: 1 },
 							endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 							endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
 						},
@@ -81,7 +81,7 @@ module.exports = {
 						type: 'object',
 						properties: {
 							...commonAttrs,
-							requestFields: { type: 'object' },
+							requestFields: { type: 'object', minProperties: 1 },
 							modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 							endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 							endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },

--- a/lib/schemas/common/generic-actions/action.js
+++ b/lib/schemas/common/generic-actions/action.js
@@ -80,6 +80,7 @@ module.exports = {
 						type: 'object',
 						properties: {
 							...commonAttrs,
+							requestFields: { type: 'object' },
 							modalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 							endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 							endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },

--- a/lib/schemas/common/generic-actions/action.js
+++ b/lib/schemas/common/generic-actions/action.js
@@ -59,6 +59,7 @@ module.exports = {
 						type: 'object',
 						properties: {
 							...commonAttrs,
+							requestFields: { type: 'object' },
 							endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 							endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
 						},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -220,7 +220,33 @@
 						"resolve": false
 					}
 				}
-			}
+			},
+			{
+        "name": "TestingActionEndpoint",
+        "kind": "generic",
+        "type": "endpoint",
+        "componentAttributes": {
+          "requestFields": {
+            "id": "testingId"
+          },
+          "icon": "link",
+          "endpoint": {
+            "service": "playground",
+            "namespace": "views-demo-massive-action",
+            "method": "post",
+						"resolve": false
+          },
+          "endpointParameters": [
+            {
+              "name": "status",
+              "target": "body",
+              "value": {
+                "static": "active"
+              }
+            }
+          ]
+        }
+      }
 		]
 	},
 	"themes": {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -188,6 +188,38 @@
 						}
 					]
 				}
+			},
+			{
+				"name": "SelectPicker",
+				"type": "form",
+				"componentAttributes": {
+					"requestFields": {
+						"id": "orderId",
+						"pickerId": "Example"
+					},
+					"icon": "user_closed",
+					"fields": [
+						{
+							"name": "pickerId",
+							"component": "UserSelector",
+							"componentAttributes": {
+								"onlyActiveUsers": true,
+								"source": {
+									"service": "service",
+									"namespace": "namespace",
+									"method": "methodName",
+									"resolve": false
+								}
+							}
+						}
+					],
+					"endpoint": {
+						"service": "picking",
+						"namespace": "session-picker-batch",
+						"method": "methodName",
+						"resolve": false
+					}
+				}
 			}
 		]
 	},

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -267,7 +267,33 @@
 						"resolve": false
 					}
 				}
-			}
+			},
+			{
+        "name": "TestingActionEndpoint",
+        "kind": "generic",
+        "type": "endpoint",
+        "componentAttributes": {
+          "requestFields": {
+            "id": "testingId"
+          },
+          "icon": "link",
+          "endpoint": {
+            "service": "playground",
+            "namespace": "views-demo-massive-action",
+            "method": "post",
+						"resolve": false
+          },
+          "endpointParameters": [
+            {
+              "name": "status",
+              "target": "body",
+              "value": {
+                "static": "active"
+              }
+            }
+          ]
+        }
+      }
 		]
 	},
 	"themes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -235,6 +235,38 @@
 						}
 					]
 				}
+			},
+			{
+				"name": "SelectPicker",
+				"type": "form",
+				"componentAttributes": {
+					"requestFields": {
+						"id": "orderId",
+						"pickerId": "Example"
+					},
+					"icon": "user_closed",
+					"fields": [
+						{
+							"name": "pickerId",
+							"component": "UserSelector",
+							"componentAttributes": {
+								"onlyActiveUsers": true,
+								"source": {
+									"service": "service",
+									"namespace": "namespace",
+									"method": "methodName",
+									"resolve": false
+								}
+							}
+						}
+					],
+					"endpoint": {
+						"service": "picking",
+						"namespace": "session-picker-batch",
+						"method": "methodName",
+						"resolve": false
+					}
+				}
 			}
 		]
 	},


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-1923

## Descripción del requerimiento
Agregar nueva prop para poder renombrar las keys a enviar en la data

## Descripción de la solución
Sumamos la prop `requestFields` a las acciones de tipo `form` y `endpoint`

## Cómo se puede probar?
- En el schema de browse se agrego una accion tipo form y endpoint, con la nueva key, podemos probar borrarla y que todo siga funcionando, tambien agregar en otro schema de browse un accion tipo form con la key y que no rompa.

Correr:
npm t
npm run test-file "ruta del archivo"
