### PR TITLE
add default value to translation keys

### DIFF
--- a/lib/schemas/edit-new/modules/components/checkList.js
+++ b/lib/schemas/edit-new/modules/components/checkList.js
@@ -7,7 +7,8 @@ const translateTypes = {
 	oneOf: [
 		{ type: 'string', pattern: '^(?!views|common)[a-zA-Z]+\\.[a-zA-Z]+$' },
 		{ type: 'boolean' }
-	]
+	],
+	default: true
 };
 
 module.exports = makeComponent({

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1196,7 +1196,6 @@ sections:
               groupField: statusName
               labelField: name
               valueField: id
-              translateSectionLabel: true
               translateGroupLabel: false
               translateCheckboxLabel: false
 
@@ -1225,7 +1224,6 @@ sections:
               groupField: statusName
               labelField: name
               valueField: id
-              translateSectionLabel: true
               translateGroupLabel: delivery.title
               translateCheckboxLabel: false
 

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1859,7 +1859,10 @@
                 "sectionField": "service",
                 "groupField": "module",
                 "labelField": "action",
-                "valueField": "key"
+                "valueField": "key",
+                "translateSectionLabel": true,
+                "translateGroupLabel": true,
+                "translateCheckboxLabel": true
               }
             },
             {


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3302

## Descripción del requerimiento
- Se necesita enviar el valor true por default desde Schema validator a las keys de traduccion del checklist

## Descripción de la solución
- Se implemento el valor por default para las keys de traducciones en checklist.js
- Se agregó el valor true en el expected json para que coincida con el esperado que es true

## Cómo se puede probar?
- Levantando la rama y ejecutando npm run test,
- Este test se ejecuta en los edit yml y json, en el caso de YML, si no se envía la key, tomara el valor true, pero tener en cuenta que hay que enviarle true en el esperado
- Si queremos darle valor string o false, se debe agregar al YML la key con el valor y tmb en el JSON

## Link a la documentación
- https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2242707533/CheckList#Traducciones


## Changelog
```
### Added
- Default value to translate keys

```
