### PR TITLE
add planning to validator

### DIFF
--- a/lib/schemas/index.js
+++ b/lib/schemas/index.js
@@ -8,6 +8,7 @@ const preview = require('./preview/schema');
 const monitor = require('./monitor/schema');
 const defaultSchema = require('./default/schema');
 const sectionSchema = require('./section/schema');
+const planning = require('./planning/schema');
 
 module.exports = {
 	browse,
@@ -17,5 +18,6 @@ module.exports = {
 	monitor,
 	preview,
 	sectionSchema,
-	defaultSchema
+	defaultSchema,
+	planning
 };

--- a/lib/schemas/planning/schema.js
+++ b/lib/schemas/planning/schema.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { properties, required } = require('../common/base');
+const filters = require('../browse/modules/filters');
+
+module.exports = {
+	type: 'object',
+	properties: {
+		...properties,
+		canRefresh: { type: 'boolean' },
+		filters
+	},
+	additionalProperties: false,
+	required
+};

--- a/tests/mocks/schemas/expected/planning.json
+++ b/tests/mocks/schemas/expected/planning.json
@@ -1,0 +1,17 @@
+{
+  "service": "tms",
+  "name": "planning",
+  "root": "Planning",
+  "title": "planning",
+  "canRefresh": false,
+  "filters": [
+    {
+      "name": "filterInput",
+      "label": "someLabel",
+      "component": "Input",
+      "componentAttributes": {
+        "icon": "iconName"
+      }
+    }
+  ]
+}

--- a/tests/mocks/schemas/planning.yml
+++ b/tests/mocks/schemas/planning.yml
@@ -1,0 +1,11 @@
+service: tms
+name: planning
+root: Planning
+title: planning
+canRefresh: false
+filters:
+  - name: filterInput
+    label: someLabel
+    component: Input
+    componentAttributes:
+      icon: iconName

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -45,6 +45,8 @@ const sectionExampleYML = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/
 const sectionExampleExpected = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/section-example.json');
 const monitorSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/monitor.yml');
 const monitorSchemaExpected = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/monitor.json');
+const planningSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/planning.yml');
+const planningSchemaExpected = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/planning.json');
 
 describe('Test validation functions', () => {
 
@@ -127,6 +129,7 @@ describe('Test validation functions', () => {
 		const previewSchema = ymljs.parse(previewSchemaYml.toString());
 		const sectionSchema = ymljs.parse(sectionExampleYML.toString());
 		const monitorSchema = ymljs.parse(monitorSchemaYml.toString());
+		const planningSchema = ymljs.parse(planningSchemaYml.toString());
 
 		const browseData = Validator.execute(browseSchema, true, '/test/data1.json');
 		const browseWithCanCreateData = Validator.execute(browseWithCanCreateSchema, true, '/test/data1.json');
@@ -148,6 +151,7 @@ describe('Test validation functions', () => {
 		const previewData = Validator.execute(previewSchema, true, '/test/data4.json');
 		const sectionData = Validator.execute(sectionSchema, true, '/test/data5.json');
 		const monitorData = Validator.execute(monitorSchema, true, '/test/data4.json');
+		const planningData = Validator.execute(planningSchema, true, '/test/data17.json');
 
 		sinon.assert.match(browseData, JSON.parse(browseSchemaExpectedJson.toString()));
 		sinon.assert.match(browseWithCanCreateData, JSON.parse(browseWithCanCreateSchemaExpectedJson.toString()));
@@ -169,6 +173,7 @@ describe('Test validation functions', () => {
 		sinon.assert.match(previewData, JSON.parse(previewSchemaExpected.toString()));
 		sinon.assert.match(sectionData, JSON.parse(sectionExampleExpected.toString()));
 		sinon.assert.match(monitorData, JSON.parse(monitorSchemaExpected.toString()));
+		sinon.assert.match(planningData, JSON.parse(planningSchemaExpected.toString()));
 	});
 
 	it('should error with default schema', () => {


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3454

## Descripción del requerimiento
- Se necesita agregar la vista de `planning` al schema validator

## Descripción de la solución
- Se agregó `planning` y sus `schemas` y test para probar
- Las props `root`, `name` y `service` son requeridas
- El `additionalProperties` esta en false por lo que no se deben poder agregar mas props

## Cómo se puede probar?
- Ingresando a la rama,
- En todos los casos, para probar todos los test, ejecutar `npm run test`
Para probara individualmente los cambios, ejecutamos
yml: `node index.js validate -i tests/mocks/schemas/planning.yml`
json: `node index.js validate -i tests/mocks/schemas/expected/planning.json`

Probar sacando y poniendo props

## Changelog
```
### Added
- Planning schema
- Planning test cases 
```
