### PR TITLE
add CapacitySlotCard to monitor valid fields

### DIFF
--- a/lib/schemas/monitor/cards/CapacitySlotCard.js
+++ b/lib/schemas/monitor/cards/CapacitySlotCard.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { capacitySlotCard } = require('./cardNames');
+const makeGenericActions = require('../../common/generic-actions');
+
+module.exports = {
+	if: {
+		properties: {
+			component: { const: capacitySlotCard }
+		}
+	},
+	then: {
+		properties: {
+			component: { type: 'string', const: capacitySlotCard },
+			actions: makeGenericActions({ customCallbacks: [] })
+		},
+		required: ['component'],
+		additionalProperties: false
+	}
+};

--- a/lib/schemas/monitor/cards/cardNames.js
+++ b/lib/schemas/monitor/cards/cardNames.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
-	baseCard: 'BaseCard'
+	baseCard: 'BaseCard',
+	capacitySlotCard: 'CapacitySlotCard'
 };

--- a/lib/schemas/monitor/cards/index.js
+++ b/lib/schemas/monitor/cards/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const BaseCard = require('./BaseCard');
+const CapacitySlotCard = require('./CapacitySlotCard');
 
 module.exports = [
-	BaseCard
+	BaseCard,
+	CapacitySlotCard
 ];

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -1,431 +1,547 @@
 {
-    "service": "picking",
-    "name": "views-demo-monitor",
-    "root": "Monitor",
-    "autoRefresh": 60,
-    "source": {
+  "service": "picking",
+  "name": "views-demo-monitor",
+  "root": "Monitor",
+  "autoRefresh": 60,
+  "source": {
+    "service": "playground",
+    "namespace": "views-demo",
+    "method": "list",
+    "resolve": false
+  },
+  "endpointParameters": [
+    {
+      "name": "status",
+      "target": "filter",
+      "value": {
+        "static": "active"
+      }
+    }
+  ],
+  "schemaSource": {
+    "type": "dynamic",
+    "endpoint": {
+      "service": "playground",
+      "namespace": "views-demo",
+      "method": "monitor",
+      "resolve": false
+    }
+  },
+  "cardLink": {
+    "path": "/route/{id}/edit",
+    "endpointParameters": [
+      {
+        "name": "id",
+        "target": "path",
+        "value": {
+          "dynamic": "id"
+        }
+      }
+    ]
+  },
+  "themes": {
+    "themeOne": {
+      "new": "black",
+      "closed": "green",
+      "_default": "grey"
+    },
+    "themeTwo": {
+      "new": "grey",
+      "closed": "fizzgreen",
+      "warning": {
+        "somePropOne": "someValue",
+        "somePropTwo": "someValue"
+      }
+    }
+  },
+  "statusBar": {
+    "field": "statusFieldName",
+    "hide": true,
+    "useTheme": true
+  },
+  "sortableFields": [
+    {
+      "name": "test",
+      "isDefaultSort": false,
+      "initialSortDirection": "desc"
+    },
+    {
+      "name": "test1",
+      "isDefaultSort": true,
+      "initialSortDirection": "desc"
+    },
+    {
+      "name": "test2",
+      "isDefaultSort": false,
+      "initialSortDirection": "asc"
+    }
+  ],
+  "featureFlags": {
+    "allowMultiSort": false
+  },
+  "filters": [
+    {
+      "name": "filterInput",
+      "component": "Input",
+      "componentAttributes": {
+        "icon": "iconName"
+      }
+    },
+    {
+      "name": "localSelect",
+      "component": "Select",
+      "componentAttributes": {
+        "translateLabels": true,
+        "options": {
+          "scope": "local",
+          "values": [
+            {
+              "label": "test",
+              "value": 1
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "dependencies": [
+    {
+      "name": "dependencyOne",
+      "source": {
+        "service": "serviceName",
+        "namespace": "namespaceName",
+        "method": "methodName",
+        "resolve": false
+      },
+      "endpointParameters": [
+        {
+          "name": "status",
+          "target": "path",
+          "value": {
+            "dynamic": "id"
+          }
+        },
+        {
+          "name": "status",
+          "target": "filter",
+          "value": {
+            "static": "active"
+          }
+        }
+      ],
+      "targetField": "fieldNameOne"
+    },
+    {
+      "name": "dependencyTwo",
+      "source": {
+        "service": "serviceName",
+        "namespace": "namespaceName",
+        "method": "methodName",
+        "resolve": false
+      },
+      "endpointParameters": [
+        {
+          "name": "status",
+          "target": "path",
+          "value": {
+            "dynamic": "id"
+          }
+        },
+        {
+          "name": "status",
+          "target": "filter",
+          "value": {
+            "static": "active"
+          }
+        }
+      ],
+      "targetField": "fieldNameTwo",
+      "dependencies": [
+        {
+          "name": "dependencyThree",
+          "source": {
+            "service": "serviceName",
+            "namespace": "namespaceName",
+            "method": "methodName",
+            "resolve": false
+          },
+          "endpointParameters": [
+            {
+              "name": "status",
+              "target": "path",
+              "value": {
+                "dynamic": "id"
+              }
+            },
+            {
+              "name": "status",
+              "target": "filter",
+              "value": {
+                "static": "active"
+              }
+            }
+          ],
+          "targetField": "fieldNameThree"
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "someCapacityCardOne",
+      "component": "CapacitySlotCard",
+      "label": "some.label.key",
+      "translateLabel": false,
+      "mapper": "addHashtag",
+      "actionsModalSize": "large",
+      "source": {
         "service": "playground",
         "namespace": "views-demo",
         "method": "list",
         "resolve": false
-    },
-    "endpointParameters": [
+      },
+      "endpointParameters": [
         {
-            "name": "status",
-            "target": "filter",
-            "value": {
-                "static": "active"
-            }
+          "name": "status",
+          "target": "filter",
+          "value": {
+            "static": "active"
+          }
         }
-    ],
-    "schemaSource": {
-        "type": "dynamic",
-        "endpoint": {
-            "service": "playground",
-            "namespace": "views-demo",
-            "method": "monitor",
-            "resolve": false
-        }
-    },
-    "cardLink": {
-        "path": "/route/{id}/edit",
-        "endpointParameters": [
-            {
+      ],
+      "actions": [
+        {
+          "name": "testEndpoint",
+          "type": "endpoint",
+          "callback": "refresh",
+          "componentAttributes": {
+            "icon": "box",
+            "endpoint": {
+              "service": "serviceName",
+              "namespace": "namespaceName",
+              "method": "methodName",
+              "resolve": false
+            },
+            "endpointParameters": [
+              {
                 "name": "id",
                 "target": "path",
                 "value": {
-                    "dynamic": "id"
+                  "dynamic": "id"
                 }
-            }
-        ]
-    },
-    "themes": {
-        "themeOne": {
-            "new": "black",
-            "closed": "green",
-            "_default": "grey"
-        },
-        "themeTwo": {
-            "new": "grey",
-            "closed": "fizzgreen",
-            "warning": {
-                "somePropOne": "someValue",
-                "somePropTwo": "someValue"
-            }
-        }
-    },
-    "statusBar": {
-        "field": "statusFieldName",
-        "hide": true,
-        "useTheme": true
-    },
-    "sortableFields": [
-        {
-            "name": "test",
-            "isDefaultSort": false,
-            "initialSortDirection": "desc"
-        },
-        {
-            "name": "test1",
-            "isDefaultSort": true,
-            "initialSortDirection": "desc"
-        },
-        {
-            "name": "test2",
-            "isDefaultSort": false,
-            "initialSortDirection": "asc"
-        }
-    ],
-    "featureFlags": {
-        "allowMultiSort": false
-    },
-    "filters": [
-        {
-            "name": "filterInput",
-            "component": "Input",
-            "componentAttributes": {
-                "icon": "iconName"
-            }
-        },
-        {
-            "name": "localSelect",
-            "component": "Select",
-            "componentAttributes": {
-                "translateLabels": true,
-                "options": {
-                    "scope": "local",
-                    "values": [
-                        {
-                            "label": "test",
-                            "value": 1
-                        }
-                    ]
-                }
-            }
-        }
-    ],
-    "dependencies": [
-        {
-            "name": "dependencyOne",
-            "source": {
-                "service": "serviceName",
-                "namespace": "namespaceName",
-                "method": "methodName",
-                "resolve": false
-            },
-            "endpointParameters": [
-                {
-                    "name": "status",
-                    "target": "path",
-                    "value": {
-                        "dynamic": "id"
-                    }
-                },
-                {
-                    "name": "status",
-                    "target": "filter",
-                    "value": {
-                        "static": "active"
-                    }
-                }
-            ],
-            "targetField": "fieldNameOne"
-        },
-        {
-            "name": "dependencyTwo",
-            "source": {
-                "service": "serviceName",
-                "namespace": "namespaceName",
-                "method": "methodName",
-                "resolve": false
-            },
-            "endpointParameters": [
-                {
-                    "name": "status",
-                    "target": "path",
-                    "value": {
-                        "dynamic": "id"
-                    }
-                },
-                {
-                    "name": "status",
-                    "target": "filter",
-                    "value": {
-                        "static": "active"
-                    }
-                }
-            ],
-            "targetField": "fieldNameTwo",
-            "dependencies": [
-                {
-                    "name": "dependencyThree",
-                    "source": {
-                        "service": "serviceName",
-                        "namespace": "namespaceName",
-                        "method": "methodName",
-                        "resolve": false
-                    },
-                    "endpointParameters": [
-                        {
-                            "name": "status",
-                            "target": "path",
-                            "value": {
-                                "dynamic": "id"
-                            }
-                        },
-                        {
-                            "name": "status",
-                            "target": "filter",
-                            "value": {
-                                "static": "active"
-                            }
-                        }
-                    ],
-                    "targetField": "fieldNameThree"
-                }
+              }
             ]
-        }
-    ],
-    "fields": [
-        {
-            "name": "someCardOne",
-            "component": "BaseCard",
-            "label": "some.label.key",
-            "translateLabel": false,
-            "mapper": "addHashtag",
-            "actionsModalSize": "large",
-            "source": {
-                "service": "playground",
-                "namespace": "views-demo",
-                "method": "list",
-                "resolve": false
-            },
-            "endpointParameters": [
-                {
-                    "name": "status",
-                    "target": "filter",
-                    "value": {
-                        "static": "active"
-                    }
-                }
-            ],
-            "actions": [
-                {
-                    "name": "testEndpoint",
-                    "type": "endpoint",
-                    "callback": "refresh",
-                    "componentAttributes": {
-                        "icon": "box",
-                        "endpoint": {
-                            "service": "serviceName",
-                            "namespace": "namespaceName",
-                            "method": "methodName",
-                            "resolve": false
-                        },
-                        "endpointParameters": [
-                            {
-                                "name": "id",
-                                "target": "path",
-                                "value": {
-                                    "dynamic": "id"
-                                }
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "testLink",
-                    "type": "link",
-                    "conditions": {
-                        "showWhen": [
-                            [
-                                {
-                                    "name": "isEqualTo",
-                                    "field": "orderData",
-                                    "innerField": "status",
-                                    "referenceValue": "active"
-                                }
-                            ]
-                        ]
-                    },
-                    "componentAttributes": {
-                        "path": "/test/{id}",
-                        "linkTarget": "_self",
-                        "endpointParameters": [
-                            {
-                                "name": "id",
-                                "target": "path",
-                                "value": {
-                                    "dynamic": "id"
-                                }
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "testForm",
-                    "type": "form",
-                    "callback": "reloadData",
-                    "componentAttributes": {
-                        "modalSize": "mobile",
-                        "endpoint": {
-                            "service": "serviceName",
-                            "namespace": "namespaceName",
-                            "method": "methodName",
-                            "resolve": false
-                        },
-                        "fields": [
-                            {
-                                "name": "fieldNameOne",
-                                "component": "Input",
-                                "componentAttributes": {}
-                            },
-                            {
-                                "name": "fieldNameTwo",
-                                "component": "Switch",
-                                "componentAttributes": {}
-                            }
-                        ]
-                    }
-                }
-            ],
-            "fieldsGroup": [
-                {
-                    "name": "info",
-                    "fields": [
-                        {
-                            "name": "someField",
-                            "component": "Text",
-                            "dependency": "dependencyOne",
-                            "componentAttributes": {}
-                        },
-                        {
-                            "name": "otherField",
-                            "component": "Chip",
-                            "componentAttributes": {
-                                "borderColor": "grey"
-                            }
-                        }
-                    ]
-                }
-            ],
-            "conditions": {
-                "matchWhen": [
-                    [
-                        {
-                            "name": "isNotEmpty",
-                            "field": [
-                                "test",
-                                "tes2"
-                            ]
-                        },
-                        {
-                            "name": "isNotEqualTo",
-                            "field": "name",
-                            "referenceValueType": "static",
-                            "referenceValue": null
-                        }
-                    ]
-                ]
-            }
+          }
         },
         {
-            "name": "someCardTwo",
-            "component": "BaseCard",
-            "source": {
-                "service": "playground",
-                "namespace": "views-demo",
-                "method": "list",
-                "resolve": false
+          "name": "testLink",
+          "type": "link",
+          "conditions": {
+            "showWhen": [
+              [
+                {
+                  "name": "isEqualTo",
+                  "field": "orderData",
+                  "innerField": "status",
+                  "referenceValue": "active"
+                }
+              ]
+            ]
+          },
+          "componentAttributes": {
+            "path": "/test/{id}",
+            "linkTarget": "_self",
+            "endpointParameters": [
+              {
+                "name": "id",
+                "target": "path",
+                "value": {
+                  "dynamic": "id"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "testForm",
+          "type": "form",
+          "callback": "reloadData",
+          "componentAttributes": {
+            "modalSize": "mobile",
+            "endpoint": {
+              "service": "serviceName",
+              "namespace": "namespaceName",
+              "method": "methodName",
+              "resolve": false
+            },
+            "fields": [
+              {
+                "name": "fieldNameOne",
+                "component": "Input",
+                "componentAttributes": {}
+              },
+              {
+                "name": "fieldNameTwo",
+                "component": "Switch",
+                "componentAttributes": {}
+              }
+            ]
+          }
+        }
+      ],
+      "conditions": {
+        "matchWhen": [
+          [
+            {
+              "name": "isNotEmpty",
+              "field": ["test", "tes2"]
+            },
+            {
+              "name": "isNotEqualTo",
+              "field": "name",
+              "referenceValueType": "static",
+              "referenceValue": null
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "name": "someCardOne",
+      "component": "BaseCard",
+      "label": "some.label.key",
+      "translateLabel": false,
+      "mapper": "addHashtag",
+      "actionsModalSize": "large",
+      "source": {
+        "service": "playground",
+        "namespace": "views-demo",
+        "method": "list",
+        "resolve": false
+      },
+      "endpointParameters": [
+        {
+          "name": "status",
+          "target": "filter",
+          "value": {
+            "static": "active"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "testEndpoint",
+          "type": "endpoint",
+          "callback": "refresh",
+          "componentAttributes": {
+            "icon": "box",
+            "endpoint": {
+              "service": "serviceName",
+              "namespace": "namespaceName",
+              "method": "methodName",
+              "resolve": false
             },
             "endpointParameters": [
-                {
-                    "name": "status",
-                    "target": "filter",
-                    "value": {
-                        "static": "active"
-                    }
+              {
+                "name": "id",
+                "target": "path",
+                "value": {
+                  "dynamic": "id"
                 }
-            ],
-            "fieldsGroup": [
+              }
+            ]
+          }
+        },
+        {
+          "name": "testLink",
+          "type": "link",
+          "conditions": {
+            "showWhen": [
+              [
                 {
-                    "name": "info",
-                    "fields": [
-                        {
-                            "name": "someField",
-                            "component": "Text",
-                            "componentAttributes": {}
-                        },
-                        {
-                            "name": "otherField",
-                            "component": "Chip",
-                            "componentAttributes": {
-                                "borderColor": "grey"
-                            }
-                        },
-                        {
-                            "name": "testChipWithLinkField",
-                            "component": "Chip",
-                            "defaultValue": "someValue",
-                            "componentAttributes": {
-                                "borderColor": "red",
-                                "textColor": "grey",
-                                "backgroundColor": "grey",
-                                "linkField": "urlField"
-                            }
-                        },
-                        {
-                            "name": "testChipWithPath",
-                            "component": "Chip",
-                            "defaultValue": "someValue",
-                            "componentAttributes": {
-                                "borderColor": "red",
-                                "textColor": "grey",
-                                "backgroundColor": "grey",
-                                "path": "/some/path/{id}"
-                            }
-                        },
-                        {
-                            "name": "testChipWithPathAndEndpointParameters",
-                            "component": "Chip",
-                            "defaultValue": "someValue",
-                            "componentAttributes": {
-                                "borderColor": "red",
-                                "textColor": "grey",
-                                "backgroundColor": "grey",
-                                "path": "/some/path/{id}",
-                                "endpointParameters": [
-                                    {
-                                        "name": "status",
-                                        "target": "path",
-                                        "value": {
-                                            "dynamic": "id"
-                                        }
-                                    },
-                                    {
-                                        "name": "status",
-                                        "target": "query",
-                                        "value": {
-                                            "static": 1
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
+                  "name": "isEqualTo",
+                  "field": "orderData",
+                  "innerField": "status",
+                  "referenceValue": "active"
                 }
-            ],
-            "conditions": {
-                "matchWhen": [
-                    [
-                        {
-                            "name": "isEqualTo",
-                            "field": "name",
-                            "referenceValue": "test"
-                        }
-                    ]
-                ]
-            }
+              ]
+            ]
+          },
+          "componentAttributes": {
+            "path": "/test/{id}",
+            "linkTarget": "_self",
+            "endpointParameters": [
+              {
+                "name": "id",
+                "target": "path",
+                "value": {
+                  "dynamic": "id"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "testForm",
+          "type": "form",
+          "callback": "reloadData",
+          "componentAttributes": {
+            "modalSize": "mobile",
+            "endpoint": {
+              "service": "serviceName",
+              "namespace": "namespaceName",
+              "method": "methodName",
+              "resolve": false
+            },
+            "fields": [
+              {
+                "name": "fieldNameOne",
+                "component": "Input",
+                "componentAttributes": {}
+              },
+              {
+                "name": "fieldNameTwo",
+                "component": "Switch",
+                "componentAttributes": {}
+              }
+            ]
+          }
         }
-    ]
+      ],
+      "fieldsGroup": [
+        {
+          "name": "info",
+          "fields": [
+            {
+              "name": "someField",
+              "component": "Text",
+              "dependency": "dependencyOne",
+              "componentAttributes": {}
+            },
+            {
+              "name": "otherField",
+              "component": "Chip",
+              "componentAttributes": {
+                "borderColor": "grey"
+              }
+            }
+          ]
+        }
+      ],
+      "conditions": {
+        "matchWhen": [
+          [
+            {
+              "name": "isNotEmpty",
+              "field": ["test", "tes2"]
+            },
+            {
+              "name": "isNotEqualTo",
+              "field": "name",
+              "referenceValueType": "static",
+              "referenceValue": null
+            }
+          ]
+        ]
+      }
+    },
+    {
+      "name": "someCardTwo",
+      "component": "BaseCard",
+      "source": {
+        "service": "playground",
+        "namespace": "views-demo",
+        "method": "list",
+        "resolve": false
+      },
+      "endpointParameters": [
+        {
+          "name": "status",
+          "target": "filter",
+          "value": {
+            "static": "active"
+          }
+        }
+      ],
+      "fieldsGroup": [
+        {
+          "name": "info",
+          "fields": [
+            {
+              "name": "someField",
+              "component": "Text",
+              "componentAttributes": {}
+            },
+            {
+              "name": "otherField",
+              "component": "Chip",
+              "componentAttributes": {
+                "borderColor": "grey"
+              }
+            },
+            {
+              "name": "testChipWithLinkField",
+              "component": "Chip",
+              "defaultValue": "someValue",
+              "componentAttributes": {
+                "borderColor": "red",
+                "textColor": "grey",
+                "backgroundColor": "grey",
+                "linkField": "urlField"
+              }
+            },
+            {
+              "name": "testChipWithPath",
+              "component": "Chip",
+              "defaultValue": "someValue",
+              "componentAttributes": {
+                "borderColor": "red",
+                "textColor": "grey",
+                "backgroundColor": "grey",
+                "path": "/some/path/{id}"
+              }
+            },
+            {
+              "name": "testChipWithPathAndEndpointParameters",
+              "component": "Chip",
+              "defaultValue": "someValue",
+              "componentAttributes": {
+                "borderColor": "red",
+                "textColor": "grey",
+                "backgroundColor": "grey",
+                "path": "/some/path/{id}",
+                "endpointParameters": [
+                  {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                      "dynamic": "id"
+                    }
+                  },
+                  {
+                    "name": "status",
+                    "target": "query",
+                    "value": {
+                      "static": 1
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "conditions": {
+        "matchWhen": [
+          [
+            {
+              "name": "isEqualTo",
+              "field": "name",
+              "referenceValue": "test"
+            }
+          ]
+        ]
+      }
+    }
+  ]
 }

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -127,6 +127,83 @@ dependencies:
         targetField: fieldNameThree
 
 fields:
+  - name: someCapacityCardOne
+    component: CapacitySlotCard
+    label: some.label.key
+    translateLabel: false
+    mapper: addHashtag
+    actionsModalSize: large
+    source:
+      service: "playground"
+      namespace: "views-demo"
+      method: "list"
+      resolve: false
+    endpointParameters:
+      - name: "status"
+        target: "filter"
+        value:
+          static: "active"
+    actions:
+      - name: testEndpoint
+        type: endpoint
+        callback: refresh
+        componentAttributes:
+          icon: box
+          endpoint:
+            service: serviceName
+            namespace: namespaceName
+            method: methodName
+            resolve: false
+          endpointParameters:
+            - name: id
+              target: path
+              value:
+                dynamic: id
+
+      - name: testLink
+        type: link
+        conditions:
+          showWhen:
+            - - name: isEqualTo
+                field: orderData
+                innerField: status
+                referenceValue: active
+        componentAttributes:
+          path: /test/{id}
+          linkTarget: _self
+          endpointParameters:
+            - name: id
+              target: path
+              value:
+                dynamic: id
+
+      - name: testForm
+        type: form
+        callback: reloadData
+        componentAttributes:
+          modalSize: mobile
+          endpoint:
+            service: serviceName
+            namespace: namespaceName
+            method: methodName
+            resolve: false
+          fields:
+            - name: fieldNameOne
+              component: Input
+            - name: fieldNameTwo
+              component: Switch
+
+    conditions:
+      matchWhen:
+        - - name: isNotEmpty
+            field:
+              - test
+              - tes2
+          - name: isNotEqualTo
+            field: name
+            referenceValueType: static
+            referenceValue: null
+
   - name: someCardOne
     component: BaseCard
     label: some.label.key
@@ -232,7 +309,7 @@ fields:
             component: Text
           - name: otherField
             component: Chip
-            
+
           - name: testChipWithLinkField
             component: Chip
             defaultValue: someValue
@@ -268,7 +345,7 @@ fields:
                   target: query
                   value:
                     static: 1
-                
+
     conditions:
       matchWhen:
         - - name: isEqualTo


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3484

## Descripción del requerimiento
- Se necesita contar con el uso de la nueva card `CapacitySlotCard` por schema ya validada desde el validadador

## Descripción de la solución
- Se creó la `card` con todo lo mismo que la **BaseCard** solo se le quitó el `fieldsGroup`
- Se agregó el caso de la nueva card en los **json** y **yml** de monitor

## Cómo se puede probar?
- Ingresando a la rama,
- En todos los casos, para probar todos los test, ejecutar `npm run test`
Para probara individualmente los cambios, ejecutamos
**yml**: `node index.js validate -i tests/mocks/schemas/monitor.yml`
**json**: `node index.js validate -i tests/mocks/schemas/expected/monitor.json`

Probar sacando y poniendo props, no debería dejar que ponga ninguna, por ejemplo no acepta `fieldsGroup`
![image](https://github.com/janis-commerce/view-schema-validator/assets/64233677/da76b999-b922-4f0c-9ae8-9fa7b976dd32)

## Changelog
```
### Added
- New card in Monitor
### Changed
- Monitor json and Yml

```
