### PR TITLE
add endpointParameters to checklist

### DIFF
--- a/lib/schemas/edit-new/modules/components/checkList.js
+++ b/lib/schemas/edit-new/modules/components/checkList.js
@@ -15,6 +15,7 @@ module.exports = makeComponent({
 	name: checkList,
 	properties: {
 		optionsSource: { $ref: 'schemaDefinitions#/definitions/endpoint' },
+		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 		options: { type: 'array', items: { type: 'object' } },
 		sectionField: { type: 'string' },
 		groupField: { type: 'string' },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1220,6 +1220,15 @@ sections:
                 namespace: claim-motive
                 method: list
                 resolve: false
+              endpointParameters:
+                - name: status
+                  target: path
+                  value:
+                    dynamic: id
+                - name: status
+                  target: filter
+                  value:
+                    static: active
               sectionField: claimMotiveName
               groupField: statusName
               labelField: name

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1875,6 +1875,22 @@
                   "method": "list",
                   "resolve": false
                 },
+                "endpointParameters": [
+                  {
+                    "name": "status",
+                    "target": "path",
+                    "value": {
+                      "dynamic": "id"
+                    }
+                  },
+                  {
+                    "name": "status",
+                    "target": "filter",
+                    "value": {
+                      "static": "active"
+                    }
+                  }
+                ],
                 "sectionField": "claimMotiveName",
                 "groupField": "statusName",
                 "labelField": "name",


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3416

## Descripción del requerimiento
- Agregar al validador del `checklist`, la posibilidad de enviarle `endpointParameters`

## Descripción de la solución
- Se agregó la definición del `endpointParameters` al componente, el mismo no es requerido
- Se agregó un ejemplo en los schemas (**ChecklistThree**) en el que se le pasan los `endpointParameters`

## Cómo se puede probar?
- Ingresando a la rama,
- En todos los casos, para probar todos los test, ejecutar `npm run test`
Para probara individualmente los cambios, ejecutamos
**yml**: `node index.js validate -i tests/mocks/schemas/edit.yml`
**json**: `node index.js validate -i tests/mocks/schemas/expected/edit.json`

## Link a la documentación
- [Checklist](https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2242707533/CheckList)

## Changelog
```
### Added
- EndpointParameters in Checklist component
```
