### PR TITLE
JMV-3509-implementar-link-por-cada-columa

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -16,13 +16,13 @@ const cardsModified = cards.map(card => modifySchemaThenProperties(card, {
 	properties: {
 		mapper,
 		name: { type: 'string' },
+		columnLink: { type: 'string' },
 		label: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		actionsModalSize: { $ref: 'schemaDefinitions#/definitions/modalSize' },
 		translateLabel: { type: 'boolean' },
 		conditions: makeConditions(false, true),
 		source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 		endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' }
-
 	},
 	requiredProperties: ['name']
 }));

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -1,547 +1,548 @@
 {
-  "service": "picking",
-  "name": "views-demo-monitor",
-  "root": "Monitor",
-  "autoRefresh": 60,
-  "source": {
-    "service": "playground",
-    "namespace": "views-demo",
-    "method": "list",
-    "resolve": false
-  },
-  "endpointParameters": [
-    {
-      "name": "status",
-      "target": "filter",
-      "value": {
-        "static": "active"
-      }
-    }
-  ],
-  "schemaSource": {
-    "type": "dynamic",
-    "endpoint": {
-      "service": "playground",
-      "namespace": "views-demo",
-      "method": "monitor",
-      "resolve": false
-    }
-  },
-  "cardLink": {
-    "path": "/route/{id}/edit",
-    "endpointParameters": [
-      {
-        "name": "id",
-        "target": "path",
-        "value": {
-          "dynamic": "id"
-        }
-      }
-    ]
-  },
-  "themes": {
-    "themeOne": {
-      "new": "black",
-      "closed": "green",
-      "_default": "grey"
-    },
-    "themeTwo": {
-      "new": "grey",
-      "closed": "fizzgreen",
-      "warning": {
-        "somePropOne": "someValue",
-        "somePropTwo": "someValue"
-      }
-    }
-  },
-  "statusBar": {
-    "field": "statusFieldName",
-    "hide": true,
-    "useTheme": true
-  },
-  "sortableFields": [
-    {
-      "name": "test",
-      "isDefaultSort": false,
-      "initialSortDirection": "desc"
-    },
-    {
-      "name": "test1",
-      "isDefaultSort": true,
-      "initialSortDirection": "desc"
-    },
-    {
-      "name": "test2",
-      "isDefaultSort": false,
-      "initialSortDirection": "asc"
-    }
-  ],
-  "featureFlags": {
-    "allowMultiSort": false
-  },
-  "filters": [
-    {
-      "name": "filterInput",
-      "component": "Input",
-      "componentAttributes": {
-        "icon": "iconName"
-      }
-    },
-    {
-      "name": "localSelect",
-      "component": "Select",
-      "componentAttributes": {
-        "translateLabels": true,
-        "options": {
-          "scope": "local",
-          "values": [
-            {
-              "label": "test",
-              "value": 1
-            }
-          ]
-        }
-      }
-    }
-  ],
-  "dependencies": [
-    {
-      "name": "dependencyOne",
-      "source": {
-        "service": "serviceName",
-        "namespace": "namespaceName",
-        "method": "methodName",
-        "resolve": false
-      },
-      "endpointParameters": [
-        {
-          "name": "status",
-          "target": "path",
-          "value": {
-            "dynamic": "id"
-          }
-        },
-        {
-          "name": "status",
-          "target": "filter",
-          "value": {
-            "static": "active"
-          }
-        }
-      ],
-      "targetField": "fieldNameOne"
-    },
-    {
-      "name": "dependencyTwo",
-      "source": {
-        "service": "serviceName",
-        "namespace": "namespaceName",
-        "method": "methodName",
-        "resolve": false
-      },
-      "endpointParameters": [
-        {
-          "name": "status",
-          "target": "path",
-          "value": {
-            "dynamic": "id"
-          }
-        },
-        {
-          "name": "status",
-          "target": "filter",
-          "value": {
-            "static": "active"
-          }
-        }
-      ],
-      "targetField": "fieldNameTwo",
-      "dependencies": [
-        {
-          "name": "dependencyThree",
-          "source": {
-            "service": "serviceName",
-            "namespace": "namespaceName",
-            "method": "methodName",
-            "resolve": false
-          },
-          "endpointParameters": [
-            {
-              "name": "status",
-              "target": "path",
-              "value": {
-                "dynamic": "id"
-              }
-            },
-            {
-              "name": "status",
-              "target": "filter",
-              "value": {
-                "static": "active"
-              }
-            }
-          ],
-          "targetField": "fieldNameThree"
-        }
-      ]
-    }
-  ],
-  "fields": [
-    {
-      "name": "someCapacityCardOne",
-      "component": "CapacitySlotCard",
-      "label": "some.label.key",
-      "translateLabel": false,
-      "mapper": "addHashtag",
-      "actionsModalSize": "large",
-      "source": {
-        "service": "playground",
-        "namespace": "views-demo",
-        "method": "list",
-        "resolve": false
-      },
-      "endpointParameters": [
-        {
-          "name": "status",
-          "target": "filter",
-          "value": {
-            "static": "active"
-          }
-        }
-      ],
-      "actions": [
-        {
-          "name": "testEndpoint",
-          "type": "endpoint",
-          "callback": "refresh",
-          "componentAttributes": {
-            "icon": "box",
-            "endpoint": {
-              "service": "serviceName",
-              "namespace": "namespaceName",
-              "method": "methodName",
-              "resolve": false
-            },
-            "endpointParameters": [
-              {
-                "name": "id",
-                "target": "path",
-                "value": {
-                  "dynamic": "id"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "testLink",
-          "type": "link",
-          "conditions": {
-            "showWhen": [
-              [
-                {
-                  "name": "isEqualTo",
-                  "field": "orderData",
-                  "innerField": "status",
-                  "referenceValue": "active"
-                }
-              ]
-            ]
-          },
-          "componentAttributes": {
-            "path": "/test/{id}",
-            "linkTarget": "_self",
-            "endpointParameters": [
-              {
-                "name": "id",
-                "target": "path",
-                "value": {
-                  "dynamic": "id"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "testForm",
-          "type": "form",
-          "callback": "reloadData",
-          "componentAttributes": {
-            "modalSize": "mobile",
-            "endpoint": {
-              "service": "serviceName",
-              "namespace": "namespaceName",
-              "method": "methodName",
-              "resolve": false
-            },
-            "fields": [
-              {
-                "name": "fieldNameOne",
-                "component": "Input",
-                "componentAttributes": {}
-              },
-              {
-                "name": "fieldNameTwo",
-                "component": "Switch",
-                "componentAttributes": {}
-              }
-            ]
-          }
-        }
-      ],
-      "conditions": {
-        "matchWhen": [
-          [
-            {
-              "name": "isNotEmpty",
-              "field": ["test", "tes2"]
-            },
-            {
-              "name": "isNotEqualTo",
-              "field": "name",
-              "referenceValueType": "static",
-              "referenceValue": null
-            }
-          ]
-        ]
-      }
-    },
-    {
-      "name": "someCardOne",
-      "component": "BaseCard",
-      "label": "some.label.key",
-      "translateLabel": false,
-      "mapper": "addHashtag",
-      "actionsModalSize": "large",
-      "source": {
-        "service": "playground",
-        "namespace": "views-demo",
-        "method": "list",
-        "resolve": false
-      },
-      "endpointParameters": [
-        {
-          "name": "status",
-          "target": "filter",
-          "value": {
-            "static": "active"
-          }
-        }
-      ],
-      "actions": [
-        {
-          "name": "testEndpoint",
-          "type": "endpoint",
-          "callback": "refresh",
-          "componentAttributes": {
-            "icon": "box",
-            "endpoint": {
-              "service": "serviceName",
-              "namespace": "namespaceName",
-              "method": "methodName",
-              "resolve": false
-            },
-            "endpointParameters": [
-              {
-                "name": "id",
-                "target": "path",
-                "value": {
-                  "dynamic": "id"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "testLink",
-          "type": "link",
-          "conditions": {
-            "showWhen": [
-              [
-                {
-                  "name": "isEqualTo",
-                  "field": "orderData",
-                  "innerField": "status",
-                  "referenceValue": "active"
-                }
-              ]
-            ]
-          },
-          "componentAttributes": {
-            "path": "/test/{id}",
-            "linkTarget": "_self",
-            "endpointParameters": [
-              {
-                "name": "id",
-                "target": "path",
-                "value": {
-                  "dynamic": "id"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "testForm",
-          "type": "form",
-          "callback": "reloadData",
-          "componentAttributes": {
-            "modalSize": "mobile",
-            "endpoint": {
-              "service": "serviceName",
-              "namespace": "namespaceName",
-              "method": "methodName",
-              "resolve": false
-            },
-            "fields": [
-              {
-                "name": "fieldNameOne",
-                "component": "Input",
-                "componentAttributes": {}
-              },
-              {
-                "name": "fieldNameTwo",
-                "component": "Switch",
-                "componentAttributes": {}
-              }
-            ]
-          }
-        }
-      ],
-      "fieldsGroup": [
-        {
-          "name": "info",
-          "fields": [
-            {
-              "name": "someField",
-              "component": "Text",
-              "dependency": "dependencyOne",
-              "componentAttributes": {}
-            },
-            {
-              "name": "otherField",
-              "component": "Chip",
-              "componentAttributes": {
-                "borderColor": "grey"
-              }
-            }
-          ]
-        }
-      ],
-      "conditions": {
-        "matchWhen": [
-          [
-            {
-              "name": "isNotEmpty",
-              "field": ["test", "tes2"]
-            },
-            {
-              "name": "isNotEqualTo",
-              "field": "name",
-              "referenceValueType": "static",
-              "referenceValue": null
-            }
-          ]
-        ]
-      }
-    },
-    {
-      "name": "someCardTwo",
-      "component": "BaseCard",
-      "source": {
-        "service": "playground",
-        "namespace": "views-demo",
-        "method": "list",
-        "resolve": false
-      },
-      "endpointParameters": [
-        {
-          "name": "status",
-          "target": "filter",
-          "value": {
-            "static": "active"
-          }
-        }
-      ],
-      "fieldsGroup": [
-        {
-          "name": "info",
-          "fields": [
-            {
-              "name": "someField",
-              "component": "Text",
-              "componentAttributes": {}
-            },
-            {
-              "name": "otherField",
-              "component": "Chip",
-              "componentAttributes": {
-                "borderColor": "grey"
-              }
-            },
-            {
-              "name": "testChipWithLinkField",
-              "component": "Chip",
-              "defaultValue": "someValue",
-              "componentAttributes": {
-                "borderColor": "red",
-                "textColor": "grey",
-                "backgroundColor": "grey",
-                "linkField": "urlField"
-              }
-            },
-            {
-              "name": "testChipWithPath",
-              "component": "Chip",
-              "defaultValue": "someValue",
-              "componentAttributes": {
-                "borderColor": "red",
-                "textColor": "grey",
-                "backgroundColor": "grey",
-                "path": "/some/path/{id}"
-              }
-            },
-            {
-              "name": "testChipWithPathAndEndpointParameters",
-              "component": "Chip",
-              "defaultValue": "someValue",
-              "componentAttributes": {
-                "borderColor": "red",
-                "textColor": "grey",
-                "backgroundColor": "grey",
-                "path": "/some/path/{id}",
-                "endpointParameters": [
-                  {
-                    "name": "status",
-                    "target": "path",
-                    "value": {
-                      "dynamic": "id"
-                    }
-                  },
-                  {
-                    "name": "status",
-                    "target": "query",
-                    "value": {
-                      "static": 1
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      ],
-      "conditions": {
-        "matchWhen": [
-          [
-            {
-              "name": "isEqualTo",
-              "field": "name",
-              "referenceValue": "test"
-            }
-          ]
-        ]
-      }
-    }
-  ]
+	"service": "picking",
+	"name": "views-demo-monitor",
+	"root": "Monitor",
+	"autoRefresh": 60,
+	"source": {
+		"service": "playground",
+		"namespace": "views-demo",
+		"method": "list",
+		"resolve": false
+	},
+	"endpointParameters": [
+		{
+			"name": "status",
+			"target": "filter",
+			"value": {
+				"static": "active"
+			}
+		}
+	],
+	"schemaSource": {
+		"type": "dynamic",
+		"endpoint": {
+			"service": "playground",
+			"namespace": "views-demo",
+			"method": "monitor",
+			"resolve": false
+		}
+	},
+	"cardLink": {
+		"path": "/route/{id}/edit",
+		"endpointParameters": [
+			{
+				"name": "id",
+				"target": "path",
+				"value": {
+					"dynamic": "id"
+				}
+			}
+		]
+	},
+	"themes": {
+		"themeOne": {
+			"new": "black",
+			"closed": "green",
+			"_default": "grey"
+		},
+		"themeTwo": {
+			"new": "grey",
+			"closed": "fizzgreen",
+			"warning": {
+				"somePropOne": "someValue",
+				"somePropTwo": "someValue"
+			}
+		}
+	},
+	"statusBar": {
+		"field": "statusFieldName",
+		"hide": true,
+		"useTheme": true
+	},
+	"sortableFields": [
+		{
+			"name": "test",
+			"isDefaultSort": false,
+			"initialSortDirection": "desc"
+		},
+		{
+			"name": "test1",
+			"isDefaultSort": true,
+			"initialSortDirection": "desc"
+		},
+		{
+			"name": "test2",
+			"isDefaultSort": false,
+			"initialSortDirection": "asc"
+		}
+	],
+	"featureFlags": {
+		"allowMultiSort": false
+	},
+	"filters": [
+		{
+			"name": "filterInput",
+			"component": "Input",
+			"componentAttributes": {
+				"icon": "iconName"
+			}
+		},
+		{
+			"name": "localSelect",
+			"component": "Select",
+			"componentAttributes": {
+				"translateLabels": true,
+				"options": {
+					"scope": "local",
+					"values": [
+						{
+							"label": "test",
+							"value": 1
+						}
+					]
+				}
+			}
+		}
+	],
+	"dependencies": [
+		{
+			"name": "dependencyOne",
+			"source": {
+				"service": "serviceName",
+				"namespace": "namespaceName",
+				"method": "methodName",
+				"resolve": false
+			},
+			"endpointParameters": [
+				{
+					"name": "status",
+					"target": "path",
+					"value": {
+						"dynamic": "id"
+					}
+				},
+				{
+					"name": "status",
+					"target": "filter",
+					"value": {
+						"static": "active"
+					}
+				}
+			],
+			"targetField": "fieldNameOne"
+		},
+		{
+			"name": "dependencyTwo",
+			"source": {
+				"service": "serviceName",
+				"namespace": "namespaceName",
+				"method": "methodName",
+				"resolve": false
+			},
+			"endpointParameters": [
+				{
+					"name": "status",
+					"target": "path",
+					"value": {
+						"dynamic": "id"
+					}
+				},
+				{
+					"name": "status",
+					"target": "filter",
+					"value": {
+						"static": "active"
+					}
+				}
+			],
+			"targetField": "fieldNameTwo",
+			"dependencies": [
+				{
+					"name": "dependencyThree",
+					"source": {
+						"service": "serviceName",
+						"namespace": "namespaceName",
+						"method": "methodName",
+						"resolve": false
+					},
+					"endpointParameters": [
+						{
+							"name": "status",
+							"target": "path",
+							"value": {
+								"dynamic": "id"
+							}
+						},
+						{
+							"name": "status",
+							"target": "filter",
+							"value": {
+								"static": "active"
+							}
+						}
+					],
+					"targetField": "fieldNameThree"
+				}
+			]
+		}
+	],
+	"fields": [
+		{
+			"name": "someCapacityCardOne",
+			"component": "CapacitySlotCard",
+			"label": "some.label.key",
+			"translateLabel": false,
+			"mapper": "addHashtag",
+			"actionsModalSize": "large",
+			"source": {
+				"service": "playground",
+				"namespace": "views-demo",
+				"method": "list",
+				"resolve": false
+			},
+			"endpointParameters": [
+				{
+					"name": "status",
+					"target": "filter",
+					"value": {
+						"static": "active"
+					}
+				}
+			],
+			"actions": [
+				{
+					"name": "testEndpoint",
+					"type": "endpoint",
+					"callback": "refresh",
+					"componentAttributes": {
+						"icon": "box",
+						"endpoint": {
+							"service": "serviceName",
+							"namespace": "namespaceName",
+							"method": "methodName",
+							"resolve": false
+						},
+						"endpointParameters": [
+							{
+								"name": "id",
+								"target": "path",
+								"value": {
+									"dynamic": "id"
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "testLink",
+					"type": "link",
+					"conditions": {
+						"showWhen": [
+							[
+								{
+									"name": "isEqualTo",
+									"field": "orderData",
+									"innerField": "status",
+									"referenceValue": "active"
+								}
+							]
+						]
+					},
+					"componentAttributes": {
+						"path": "/test/{id}",
+						"linkTarget": "_self",
+						"endpointParameters": [
+							{
+								"name": "id",
+								"target": "path",
+								"value": {
+									"dynamic": "id"
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "testForm",
+					"type": "form",
+					"callback": "reloadData",
+					"componentAttributes": {
+						"modalSize": "mobile",
+						"endpoint": {
+							"service": "serviceName",
+							"namespace": "namespaceName",
+							"method": "methodName",
+							"resolve": false
+						},
+						"fields": [
+							{
+								"name": "fieldNameOne",
+								"component": "Input",
+								"componentAttributes": {}
+							},
+							{
+								"name": "fieldNameTwo",
+								"component": "Switch",
+								"componentAttributes": {}
+							}
+						]
+					}
+				}
+			],
+			"conditions": {
+				"matchWhen": [
+					[
+						{
+							"name": "isNotEmpty",
+							"field": ["test", "tes2"]
+						},
+						{
+							"name": "isNotEqualTo",
+							"field": "name",
+							"referenceValueType": "static",
+							"referenceValue": null
+						}
+					]
+				]
+			}
+		},
+		{
+			"name": "someCardOne",
+			"columnLink": "www.janis.im",
+			"component": "BaseCard",
+			"label": "some.label.key",
+			"translateLabel": false,
+			"mapper": "addHashtag",
+			"actionsModalSize": "large",
+			"source": {
+				"service": "playground",
+				"namespace": "views-demo",
+				"method": "list",
+				"resolve": false
+			},
+			"endpointParameters": [
+				{
+					"name": "status",
+					"target": "filter",
+					"value": {
+						"static": "active"
+					}
+				}
+			],
+			"actions": [
+				{
+					"name": "testEndpoint",
+					"type": "endpoint",
+					"callback": "refresh",
+					"componentAttributes": {
+						"icon": "box",
+						"endpoint": {
+							"service": "serviceName",
+							"namespace": "namespaceName",
+							"method": "methodName",
+							"resolve": false
+						},
+						"endpointParameters": [
+							{
+								"name": "id",
+								"target": "path",
+								"value": {
+									"dynamic": "id"
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "testLink",
+					"type": "link",
+					"conditions": {
+						"showWhen": [
+							[
+								{
+									"name": "isEqualTo",
+									"field": "orderData",
+									"innerField": "status",
+									"referenceValue": "active"
+								}
+							]
+						]
+					},
+					"componentAttributes": {
+						"path": "/test/{id}",
+						"linkTarget": "_self",
+						"endpointParameters": [
+							{
+								"name": "id",
+								"target": "path",
+								"value": {
+									"dynamic": "id"
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "testForm",
+					"type": "form",
+					"callback": "reloadData",
+					"componentAttributes": {
+						"modalSize": "mobile",
+						"endpoint": {
+							"service": "serviceName",
+							"namespace": "namespaceName",
+							"method": "methodName",
+							"resolve": false
+						},
+						"fields": [
+							{
+								"name": "fieldNameOne",
+								"component": "Input",
+								"componentAttributes": {}
+							},
+							{
+								"name": "fieldNameTwo",
+								"component": "Switch",
+								"componentAttributes": {}
+							}
+						]
+					}
+				}
+			],
+			"fieldsGroup": [
+				{
+					"name": "info",
+					"fields": [
+						{
+							"name": "someField",
+							"component": "Text",
+							"dependency": "dependencyOne",
+							"componentAttributes": {}
+						},
+						{
+							"name": "otherField",
+							"component": "Chip",
+							"componentAttributes": {
+								"borderColor": "grey"
+							}
+						}
+					]
+				}
+			],
+			"conditions": {
+				"matchWhen": [
+					[
+						{
+							"name": "isNotEmpty",
+							"field": ["test", "tes2"]
+						},
+						{
+							"name": "isNotEqualTo",
+							"field": "name",
+							"referenceValueType": "static",
+							"referenceValue": null
+						}
+					]
+				]
+			}
+		},
+		{
+			"name": "someCardTwo",
+			"component": "BaseCard",
+			"source": {
+				"service": "playground",
+				"namespace": "views-demo",
+				"method": "list",
+				"resolve": false
+			},
+			"endpointParameters": [
+				{
+					"name": "status",
+					"target": "filter",
+					"value": {
+						"static": "active"
+					}
+				}
+			],
+			"fieldsGroup": [
+				{
+					"name": "info",
+					"fields": [
+						{
+							"name": "someField",
+							"component": "Text",
+							"componentAttributes": {}
+						},
+						{
+							"name": "otherField",
+							"component": "Chip",
+							"componentAttributes": {
+								"borderColor": "grey"
+							}
+						},
+						{
+							"name": "testChipWithLinkField",
+							"component": "Chip",
+							"defaultValue": "someValue",
+							"componentAttributes": {
+								"borderColor": "red",
+								"textColor": "grey",
+								"backgroundColor": "grey",
+								"linkField": "urlField"
+							}
+						},
+						{
+							"name": "testChipWithPath",
+							"component": "Chip",
+							"defaultValue": "someValue",
+							"componentAttributes": {
+								"borderColor": "red",
+								"textColor": "grey",
+								"backgroundColor": "grey",
+								"path": "/some/path/{id}"
+							}
+						},
+						{
+							"name": "testChipWithPathAndEndpointParameters",
+							"component": "Chip",
+							"defaultValue": "someValue",
+							"componentAttributes": {
+								"borderColor": "red",
+								"textColor": "grey",
+								"backgroundColor": "grey",
+								"path": "/some/path/{id}",
+								"endpointParameters": [
+									{
+										"name": "status",
+										"target": "path",
+										"value": {
+											"dynamic": "id"
+										}
+									},
+									{
+										"name": "status",
+										"target": "query",
+										"value": {
+											"static": 1
+										}
+									}
+								]
+							}
+						}
+					]
+				}
+			],
+			"conditions": {
+				"matchWhen": [
+					[
+						{
+							"name": "isEqualTo",
+							"field": "name",
+							"referenceValue": "test"
+						}
+					]
+				]
+			}
+		}
+	]
 }

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -134,15 +134,15 @@ fields:
     mapper: addHashtag
     actionsModalSize: large
     source:
-      service: "playground"
-      namespace: "views-demo"
-      method: "list"
+      service: 'playground'
+      namespace: 'views-demo'
+      method: 'list'
       resolve: false
     endpointParameters:
-      - name: "status"
-        target: "filter"
+      - name: 'status'
+        target: 'filter'
         value:
-          static: "active"
+          static: 'active'
     actions:
       - name: testEndpoint
         type: endpoint
@@ -205,21 +205,22 @@ fields:
             referenceValue: null
 
   - name: someCardOne
+    columnLink: 'www.janis.im'
     component: BaseCard
     label: some.label.key
     translateLabel: false
     mapper: addHashtag
     actionsModalSize: large
     source:
-      service: "playground"
-      namespace: "views-demo"
-      method: "list"
+      service: 'playground'
+      namespace: 'views-demo'
+      method: 'list'
       resolve: false
     endpointParameters:
-      - name: "status"
-        target: "filter"
+      - name: 'status'
+        target: 'filter'
         value:
-          static: "active"
+          static: 'active'
     actions:
       - name: testEndpoint
         type: endpoint
@@ -292,15 +293,15 @@ fields:
   - name: someCardTwo
     component: BaseCard
     source:
-      service: "playground"
-      namespace: "views-demo"
-      method: "list"
+      service: 'playground'
+      namespace: 'views-demo'
+      method: 'list'
       resolve: false
     endpointParameters:
-      - name: "status"
-        target: "filter"
+      - name: 'status'
+        target: 'filter'
         value:
-          static: "active"
+          static: 'active'
 
     fieldsGroup:
       - name: info


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3508

## Descripción del requerimiento
- Se debe agregar la key `columnLink` dentro del schema del monitor para que el back la pueda utilizar

## Descripción de la solución
- Se agregó la key mencionada dentro de _lib/schemas/monitor/schema.js_

## Cómo se puede probar?
- Ingresar a la branch, correr los tests (se podría agregar la nueva como key como required para verificar que los tests no pasan si no se agrega la misma)

yml: `node index.js validate -i tests/mocks/schemas/monitor.yml`
json: `node index.js validate -i tests/mocks/schemas/expected/monitor.json`

![image](https://github.com/janis-commerce/view-schema-validator/assets/59315051/f2f049df-0d8e-4363-a8b0-45fc3603df4d)

## Link a la documentación


## Datos extra a tener en cuenta


## Changelog
```
### Added
- columnLink key in monitor schema
```
