### PR TITLE
JMV-3511-modificar-tamaño-de-card

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -64,7 +64,9 @@ module.exports = {
 				allOf: cardsModified
 			},
 			minItems: 1
-		}
+		},
+		columnsWidth: { type: 'number' },
+		columnsQuantityScroll: { type: 'number' }
 	},
 	additionalProperties: false,
 	required: [...required]

--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -44,6 +44,8 @@ module.exports = {
 		cardLink: {
 			oneOf: [{ const: false }, customLink]
 		},
+		columnsWidth: { type: 'number' },
+		columnsQuantityScroll: { type: 'number' },
 		schemaSource: {
 			type: 'object',
 			properties: {
@@ -64,9 +66,7 @@ module.exports = {
 				allOf: cardsModified
 			},
 			minItems: 1
-		},
-		columnsWidth: { type: 'number' },
-		columnsQuantityScroll: { type: 'number' }
+		}
 	},
 	additionalProperties: false,
 	required: [...required]

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -39,6 +39,8 @@
 			}
 		]
 	},
+	"columnsWidth": 25,
+	"columnsQuantityScroll": 4,
 	"themes": {
 		"themeOne": {
 			"new": "black",
@@ -550,7 +552,5 @@
 				]
 			}
 		}
-	],
-	"columnsWidth": 25,
-	"columnsQuantityScroll": 4
+	]
 }

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -294,7 +294,10 @@
 					[
 						{
 							"name": "isNotEmpty",
-							"field": ["test", "tes2"]
+							"field": [
+								"test",
+								"tes2"
+							]
 						},
 						{
 							"name": "isNotEqualTo",
@@ -434,7 +437,10 @@
 					[
 						{
 							"name": "isNotEmpty",
-							"field": ["test", "tes2"]
+							"field": [
+								"test",
+								"tes2"
+							]
 						},
 						{
 							"name": "isNotEqualTo",
@@ -544,5 +550,7 @@
 				]
 			}
 		}
-	]
+	],
+	"columnsWidth": 25,
+	"columnsQuantityScroll": 4
 }

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -32,6 +32,9 @@ cardLink:
       value:
         dynamic: id
 
+columnsWidth: 25
+columnsQuantityScroll: 4
+
 themes:
   themeOne:
     new: black
@@ -352,5 +355,3 @@ fields:
         - - name: isEqualTo
             field: name
             referenceValue: test
-columnsWidth: 25
-columnsQuantityScroll: 4

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -352,3 +352,5 @@ fields:
         - - name: isEqualTo
             field: name
             referenceValue: test
+columnsWidth: 25
+columnsQuantityScroll: 4


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3510
## Descripción del requerimiento
- Se deben agregar la key `columnsWidth` y `columnsQuantityScroll` dentro del schema del monitor para que el back la pueda utilizar
## Descripción de la solución
- Se agregaron las keys mencionada dentro de _lib/schemas/monitor/schema.js_
## Cómo se puede probar?
Ingresar a la branch, correr los tests:

`yml: node index.js validate -i tests/mocks/schemas/monitor.yml`
`json: node index.js validate -i tests/mocks/schemas/expected/monitor.json`

Revisar que los test corran correctamente
## Link a la documentación

## Datos extra a tener en cuenta

## Changelog
```
### Added

- columnsWidth & columnsQuantityScroll keys in monitor schema root
```
