### PR TITLE
JMV-3511-modificar-tamaño-de-card

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -44,7 +44,7 @@ module.exports = {
 		cardLink: {
 			oneOf: [{ const: false }, customLink]
 		},
-		columnsWidth: { type: 'number' },
+		columnsWidth: { type: ['number', 'string'] },
 		columnsQuantityScroll: { type: 'number' },
 		schemaSource: {
 			type: 'object',

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -39,7 +39,7 @@
 			}
 		]
 	},
-	"columnsWidth": "320px",
+	"columnsWidth": 25,
 	"columnsQuantityScroll": 4,
 	"themes": {
 		"themeOne": {

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -39,7 +39,7 @@
 			}
 		]
 	},
-	"columnsWidth": 25,
+	"columnsWidth": "320px",
 	"columnsQuantityScroll": 4,
 	"themes": {
 		"themeOne": {


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3510
## Descripción del requerimiento
- Se debe validar que la propiedad `columnsWidth` acepte también un valor de tipo string
## Descripción de la solución
- Se agregó el tipo "string" en la key `type` de la propiedad `columnsWidth`
## Cómo se puede probar?
Ingresar a la branch, correr los tests:

yml: `node index.js validate -i tests/mocks/schemas/monitor.yml`
json: `node index.js validate -i tests/mocks/schemas/expected/monitor.json`

Revisar que los test corran correctamente
## Link a la documentación

## Datos extra a tener en cuenta

## Changelog
```
### Changed
- columnsWidth key type, monitor json example
```
