### PR TITLE
add canCopy prop on code component

### DIFF
--- a/lib/schemas/edit-new/modules/components/code.js
+++ b/lib/schemas/edit-new/modules/components/code.js
@@ -8,6 +8,7 @@ module.exports = makeComponent({
 	properties: {
 		language: { type: 'string' },
 		canEdit: { type: 'boolean' },
+		canCopy: { type: 'boolean' },
 		minLines: { type: 'number' },
 		maxLines: { type: 'number' }
 	}

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -650,6 +650,7 @@ sections:
             component: Code
             componentAttributes:
               language: json
+              canCopy: false
               canEdit: true
               minLines: 5
               maxLines: 15

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1027,6 +1027,7 @@
               "component": "Code",
               "componentAttributes": {
                 "language": "json",
+                "canCopy": false,
                 "canEdit": true,
                 "minLines": 5,
                 "maxLines": 15


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3534

## Descripción del requerimiento
- Agregar al validador del `Code`, la posibilidad de enviarle `canCopy`

## Descripción de la solución
- Se agregó la definición del booleano `canCopy` al componente
- Se agregó el caso en los test del edit

## Cómo se puede probar?
- Ingresando a la rama,
- En todos los casos, para probar todos los test, ejecutar `npm run test`
Para probara individualmente los cambios, ejecutamos
**yml**: `node index.js validate -i tests/mocks/schemas/edit.yml`
**json**: `node index.js validate -i tests/mocks/schemas/expected/edit.json`

## Link a la documentación
- [Code](https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2242773030/Code)

## Changelog
```
### Added
- canCopy to Code component
```