### PR TITLE
JMV-3573-ocultar-columnas-vacias-en-monitor

### DIFF
--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -46,7 +46,7 @@ module.exports = {
 		},
 		columnsWidth: { type: ['number', 'string'] },
 		columnsQuantityScroll: { type: 'number' },
-		hideEmptyColumns: { type: 'boolean' },
+		hideEmptyColumns: { type: 'boolean', default: false },
 		schemaSource: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/monitor/schema.js
+++ b/lib/schemas/monitor/schema.js
@@ -46,6 +46,7 @@ module.exports = {
 		},
 		columnsWidth: { type: ['number', 'string'] },
 		columnsQuantityScroll: { type: 'number' },
+		hideEmptyColumns: { type: 'boolean' },
 		schemaSource: {
 			type: 'object',
 			properties: {

--- a/tests/mocks/schemas/expected/monitor.json
+++ b/tests/mocks/schemas/expected/monitor.json
@@ -41,6 +41,7 @@
 	},
 	"columnsWidth": 25,
 	"columnsQuantityScroll": 4,
+	"hideEmptyColumns": false,
 	"themes": {
 		"themeOne": {
 			"new": "black",

--- a/tests/mocks/schemas/monitor.yml
+++ b/tests/mocks/schemas/monitor.yml
@@ -34,6 +34,7 @@ cardLink:
 
 columnsWidth: 25
 columnsQuantityScroll: 4
+hideEmptyColumns: false
 
 themes:
   themeOne:


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3570
## Descripción del requerimiento
Agregar la key `hideEmptyColumns` que sea de tipo boolean y tenga `false` como valor por default
## Descripción de la solución
Se agregó la key correspondiente en el archivo _lib/schemas/monitor/schema.js_
## Cómo se puede probar?
Ingresar a la branch, correr los tests:

`yml: node index.js validate -i tests/mocks/schemas/monitor.yml`
`json: node index.js validate -i tests/mocks/schemas/expected/monitor.json`

## Link a la documentación
## Datos extra a tener en cuenta
## Changelog
```
### Added

- hideEmptyColumns key in monitor schema
```
