### PR TITLE
JMV-3557-implementacion-componente-para-resetear-contraseña

### DIFF
--- a/lib/schemas/common/actions/action.js
+++ b/lib/schemas/common/actions/action.js
@@ -58,6 +58,7 @@ module.exports = {
 					properties: {
 						endpoint: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 						endpointParameters,
+						modalTitle: { type: 'string' },
 						fields: {
 							type: 'array',
 							items: { $ref: 'schemaDefinitions#/definitions/actionField' },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -250,6 +250,7 @@ sections:
                   target: path
                   value:
                     dynamic: id
+              modalTitle: testModalTitle
               fields:
                 - name: password
                   label: login.field.temporaryPassword

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -385,6 +385,7 @@
                     }
                   }
                 ],
+								"modalTitle": "testModalTitle",
 								"fields": [
 									{
 										"attributes": {


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3542
## Descripción del requerimiento
Agregar la key `modalTitle` al schema del action sólo cuando el callback es `openModal`
## Descripción de la solución
- Se agregó la nueva key al schema correspondiente
## Cómo se puede probar?
Ingresar a la branch, correr los tests, ejemplo:

yml: `node index.js validate -i tests/mocks/schemas/edit.yml`
json: `node index.js validate -i tests/mocks/schemas/expected/edit.json`
## Link a la documentación

## Datos extra a tener en cuenta

## Changelog
```
### Added
- modalTitle key in action schema
```