### PR TITLE
add width definition

### DIFF
--- a/lib/schemas/browse/modules/field-appearance.js
+++ b/lib/schemas/browse/modules/field-appearance.js
@@ -19,15 +19,7 @@ const appearanceProps = {
 		},
 		align: { enum: ['left', 'center', 'right'] },
 		verticalAlign: { enum: ['top', 'center', 'bottom'] },
-		width: {
-			oneOf: [
-				{ type: 'number' },
-				{
-					type: 'string',
-					pattern: '^auto$|^([0-9]|[1-8][0-9]|9[0-9]|100)%$|^[0-9]+px$'
-				}
-			]
-		}
+		width: { $ref: 'schemaDefinitions#/definitions/width' }
 	},
 	additionalProperties: false,
 	minProperties: 1

--- a/lib/schemas/common/width.js
+++ b/lib/schemas/common/width.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+	oneOf: [
+		{ type: 'number' },
+		{
+			type: 'string',
+			pattern: '^auto$|^([0-9]|[1-8][0-9]|9[0-9]|100)%$|^[0-9]+px$'
+		}
+	]
+};

--- a/lib/schemas/definitions/index.js
+++ b/lib/schemas/definitions/index.js
@@ -13,6 +13,7 @@ const template = require('../common/template');
 const featureFlags = require('../common/featureFlags');
 const redirect = require('../common/redirect');
 const canCreate = require('../common/canCreate');
+const width = require('../common/width');
 
 module.exports = {
 	$id: 'schemaDefinitions',
@@ -29,6 +30,7 @@ module.exports = {
 		graphs,
 		endpointParameters: getEndpointParameters(),
 		featureFlags,
-		canCreate
+		canCreate,
+		width
 	}
 };

--- a/lib/schemas/edit-new/modules/field.js
+++ b/lib/schemas/edit-new/modules/field.js
@@ -19,7 +19,7 @@ module.exports = {
 		translateLabel: { type: 'boolean' },
 		floatingLabel: { type: 'boolean' },
 		dependency: { type: 'string' },
-		width: { type: 'number' },
+		width: { $ref: 'schemaDefinitions#/definitions/width' },
 		position: { type: 'string', enum: ['left', 'right'] },
 		attributes,
 		defaultValue: {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -412,6 +412,7 @@ sections:
 
           - name: exampleTextCurrency
             component: Text
+            width: 25%
             dependency: dependencyName
             mapper:
               name: currency
@@ -421,6 +422,7 @@ sections:
 
           - name: exampleTextSuffix
             component: Text
+            width: 25px
             mapper:
               name: suffix
               props:
@@ -430,6 +432,7 @@ sections:
 
           - name: exampleTextPrefix
             component: Text
+            width: auto
             defaultValueField: someField
             mapper:
               name: prefix

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -443,6 +443,7 @@ sections:
 
           - name: exampleTextWithIcon
             component: Text
+            width: 50
             componentAttributes:
               icon: iconName
               iconColor: colorName

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -706,6 +706,7 @@
             {
               "name": "exampleTextWithIcon",
               "component": "Text",
+              "width": 50,
               "componentAttributes": {
                 "icon": "iconName",
                 "iconColor": "colorName",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -663,6 +663,7 @@
             {
               "name": "exampleTextCurrency",
               "component": "Text",
+              "width": "25%",
               "dependency": "dependencyName",
               "mapper": {
                 "name": "currency",
@@ -676,6 +677,7 @@
             {
               "name": "exampleTextSuffix",
               "component": "Text",
+              "width": "25px",
               "mapper": {
                 "name": "suffix",
                 "props": {
@@ -689,6 +691,7 @@
             {
               "name": "exampleTextPrefix",
               "component": "Text",
+              "width": "auto",
               "defaultValueField": "someField",
               "mapper": {
                 "name": "prefix",


### PR DESCRIPTION
## Link al ticket
- No hay, se generó a traves de [una consulta del canal de slack](https://janiscommerce.slack.com/archives/CASE3VALU/p1728471146811969)

## Descripción del requerimiento
- Se necesita que el `field` utilizado en las secciones de los `edit/new`, permitan utilizar la prop `width` que ya tienen pero aceptando ademas de numero un `string`
Esto por lo visto ya está utilizándose y de hecho encontré el caso del `field-appearance`, que ya tiene armado el `oneOf` que necesitamos

**El funcionamiento del width debe ser**
- Debe poder recibir un número. Si lo recibe, del lado de `Views` aplicamos ese numero como porcentaje (**50**)
-  Debe poder recibir un `string` pero ese `string` debe ser `auto`, o un número que termine con **px** o **%**, ya que si el valor que llegue es texto, se utiliza desde `Views` directamente como el `width`

## Descripción de la solución
- Se creó una definición para el `width`, la misma permite que el valor del mismo sea un número o un texto igual a "auto" o un número que termine en `px` o `%`
- Se agregó la definición tanto en `field-appearance` ya que la copie d esa que estaba funcionando como en el `width` de los fields de los `edit-new`
- Se agregaron test en los componentes `Text` de los `edit` (json y yml) tanto si recibe numero, string con % o px y auto

## Cómo se puede probar?
- Ingresando a la rama, corriendo `npm run test` debería mantenerse sin errores
- Se puede probar cambiando los valores del `width` agregado en alguno de los `Text`, probar con todos los test a todo o individualmente a los dos archivos que utilizamos 

`YML => node index.js validate -i tests/mocks/schemas/edit.yml`
`JSON => node index.js validate -i tests/mocks/schemas/expected/edit.json`

Si no cumple el funcionamiento mencionado arriba debería romper el test

## Changelog
```
### Added
- Width definition
- Width definition uses
```
