### PR TITLE
Added key imageFieldName to Select and Multiselect components

### DIFF
--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -15,6 +15,7 @@ module.exports = makeComponent({
 		preloadOptions: { type: 'boolean' },
 		responseProperty: { type: 'string' },
 		translateGroupLabel: { type: 'boolean' },
+		imageFieldName: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -15,7 +15,7 @@ module.exports = makeComponent({
 		preloadOptions: { type: 'boolean' },
 		responseProperty: { type: 'string' },
 		translateGroupLabel: { type: 'boolean' },
-		imageFieldName: { type: 'string' },
+		imageField: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/edit-new/modules/components/selectMultilevel.js
+++ b/lib/schemas/edit-new/modules/components/selectMultilevel.js
@@ -16,6 +16,7 @@ module.exports = makeComponent({
 		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },
+		imageField: { type: 'string' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -18,6 +18,7 @@ module.exports = makeComponent({
 		canCreate: { type: 'boolean' },
 		responseProperty: { type: 'string' },
 		translateGroupLabel: { type: 'boolean' },
+		imageField: { type: 'string' },
 		targetField: {
 			oneOf: [
 				{ type: 'string' },

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -661,7 +661,7 @@
 			"component": "Select",
 			"componentAttributes": {
 				"translateLabels": true,
-				"imageFieldName": "imageUrl",
+				"imageField": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"endpoint": {
@@ -679,7 +679,7 @@
 			"component": "Multiselect",
 			"componentAttributes": {
 				"translateLabels": true,
-				"imageFieldName": "imageUrl",
+				"imageField": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"initialValuesEndpoint": {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -661,6 +661,7 @@
 			"component": "Select",
 			"componentAttributes": {
 				"translateLabels": true,
+				"imageFieldName": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"endpoint": {
@@ -678,6 +679,7 @@
 			"component": "Multiselect",
 			"componentAttributes": {
 				"translateLabels": true,
+				"imageFieldName": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"initialValuesEndpoint": {

--- a/tests/mocks/schemas/edit-with-actions-source.yml
+++ b/tests/mocks/schemas/edit-with-actions-source.yml
@@ -1090,6 +1090,7 @@ sections:
             component: Select
             componentAttributes:
               translateLabels: true
+              imageField: imageUrl
               options:
                 scope: remote
                 endpoint:
@@ -1107,6 +1108,7 @@ sections:
               parentFilterDefaultValue: 'null'
               canClear: true
               maxLevel: 3
+              imageField: imageUrl
               options:
                 scope: remote
                 endpoint:

--- a/tests/mocks/schemas/edit-with-sources.yml
+++ b/tests/mocks/schemas/edit-with-sources.yml
@@ -97,6 +97,7 @@ sections:
       component: Multiselect
       componentAttributes:
         translateLabels: false
+        imageField: imageUrl
         options:
           scope: remote
           endpoint:

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -721,7 +721,7 @@
 			"component": "Select",
 			"componentAttributes": {
 				"translateLabels": true,
-				"imageFieldName": "imageUrl",
+				"imageField": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"searchParam": "filters[search]",
@@ -744,7 +744,7 @@
 			"component": "Multiselect",
 			"componentAttributes": {
 				"translateLabels": true,
-				"imageFieldName": "imageUrl",
+				"imageField": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"searchParam": "filters[search]",

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -721,6 +721,7 @@
 			"component": "Select",
 			"componentAttributes": {
 				"translateLabels": true,
+				"imageFieldName": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"searchParam": "filters[search]",
@@ -743,6 +744,7 @@
 			"component": "Multiselect",
 			"componentAttributes": {
 				"translateLabels": true,
+				"imageFieldName": "imageUrl",
 				"options": {
 					"scope": "remote",
 					"searchParam": "filters[search]",

--- a/tests/mocks/schemas/expected/edit-with-actions-source.json
+++ b/tests/mocks/schemas/expected/edit-with-actions-source.json
@@ -1724,6 +1724,7 @@
 							"component": "Select",
 							"componentAttributes": {
 								"translateLabels": true,
+								"imageField": "imageUrl",
 								"options": {
 									"scope": "remote",
 									"searchParam": "filters[search]",
@@ -1750,6 +1751,7 @@
 								"parentFilterDefaultValue": "null",
 								"canClear": true,
 								"maxLevel": 3,
+								"imageField": "imageUrl",
 								"options": {
 									"scope": "remote",
 									"searchParam": "filters[search]",

--- a/tests/mocks/schemas/expected/edit-with-sources.json
+++ b/tests/mocks/schemas/expected/edit-with-sources.json
@@ -193,6 +193,7 @@
                             "component": "Multiselect",
                             "componentAttributes": {
                                 "translateLabels": false,
+                                "imageField": "imageUrl",
                                 "options": {
                                     "scope": "remote",
                                     "endpoint": {


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3633
## Descripción del requerimiento
Se requiere agregar la key imageField para poder agregar imagenes a Select y Multiselect 
## Descripción de la solución
- Se agrego la key imageField al schema de Select y Multiselect
- Se agregaron casos de prueba para browse 
## Cómo se puede probar?
- Entrar a la rama 
- Correr el comando npm run test
- Deben pasar los test con la key
- Quitar imageField de los test browse.json y de expected/browse.json 
- Volver a correr el comando npm run test
- Deben pasar los test sin la key
- Quitar imageField de los test edit-with-source.yml y de expected/edit-with-source.json
- Volver a correr el comando npm run test
- Deben pasar los test sin la key
- Quitar imageField de los test de edit-with-actions-source.yml y de expected/edit-with-actions-source.json
- Volver a correr el comando npm run test
- Deben pasar los test sin la key
- Agregar la key a un UserSelector, StatusSelector e IconSelector tanto en el json como en el expected/json
- Debe romper los test con la key tanto para UserSelector, IconSelector y StatusSelector
## Link a la documentación
-
## Datos extra a tener en cuenta
- UserSelector, IconSelector y StatusSelector no permiten la key nueva porque son Selects custom con su propia funcionalidad
## Changelog
```
### Added
- Key imageField to Select and Multiselect in Filters and Edits
- Key imageField to SelectMultilevel
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
