### PR TITLE
Added link to dashboard graphs

### DIFF
--- a/lib/schemas/common/graphs.js
+++ b/lib/schemas/common/graphs.js
@@ -51,6 +51,7 @@ const baseSchemaProperties = {
 	source: { $ref: 'schemaDefinitions#/definitions/endpoint' },
 	endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
 	componentAttributes: { type: 'object' },
+	link: { type: 'string' },
 	x: { type: 'number' },
 	y: { type: 'number' },
 	width: { type: 'number' },

--- a/tests/mocks/schemas/dashboard-with-links.yml
+++ b/tests/mocks/schemas/dashboard-with-links.yml
@@ -1,0 +1,79 @@
+service: serviceName
+name: example-dashboard
+root: Dashboard
+filters:
+  - name: filterInput
+    label: someLabel
+    component: Input
+    componentAttributes:
+      icon: iconName
+graphs:
+  - component: Table
+    name: graphName
+    title: someTitleForGraph
+    x: 0
+    y: 0
+    width: 6
+    height: 3
+    link: /test
+
+  - component: BarChart
+    name: graphName
+    title: someTitleForGraph
+    translateTitle: true
+    subtitle: someSubtitleForGraph
+    translateSubtitle: true
+    componentAttributes:
+      options:
+        width: 100%
+    x: 6
+    y: 0
+    width: 6
+    height: 3
+    link: /test
+
+  - component: TextCardKpi
+    name: TextCard
+    title: title
+    value:
+      field: someField
+      mapper:
+        name: suffix
+        props:
+          addWhitespace: true
+          value: 'hs'
+    percent:
+      field: someField
+      mapper:
+        name: suffix
+        props:
+          addWhitespace: true
+          value: '%'
+    x: 0
+    y: 0
+    width: 12
+    height: 4
+    link: /test
+  - component: TextCardKpi
+    name: TextCardDelivery
+    title: title
+    value:
+      field: someField
+      mapper:
+        name: suffix
+        props:
+          addWhitespace: true
+          value: 'hs'
+    percent:
+      field: someField
+      mapper:
+        name: suffix
+        props:
+          addWhitespace: true
+          value: '%'
+    x: 0
+    y: 0
+    width: 12
+    height: 4
+
+

--- a/tests/mocks/schemas/expected/dashboard-with-links.json
+++ b/tests/mocks/schemas/expected/dashboard-with-links.json
@@ -1,0 +1,108 @@
+{
+	"service": "serviceName",
+	"name": "example-dashboard",
+	"root": "Dashboard",
+	"filters": [
+		{
+			"name": "filterInput",
+			"label": "someLabel",
+			"component": "Input",
+			"componentAttributes": {
+				"icon": "iconName"
+			}
+		}
+	],
+	"graphs": [
+		{
+			"component": "Table",
+			"filters": [],
+			"name": "graphName",
+			"title": "someTitleForGraph",
+			"x": 0,
+			"y": 0,
+			"width": 6,
+			"height": 3,
+			"link": "/test"
+		},
+		{
+			"component": "BarChart",
+			"filters": [],
+			"name": "graphName",
+			"title": "someTitleForGraph",
+			"translateTitle": true,
+			"subtitle": "someSubtitleForGraph",
+			"translateSubtitle": true,
+			"componentAttributes": {
+				"options": {
+					"width": "100%"
+				}
+			},
+			"x": 6,
+			"y": 0,
+			"width": 6,
+			"height": 3,
+			"link": "/test"
+		},
+		{
+			"component": "TextCardKpi",
+			"filters": [],
+			"name": "TextCard",
+			"title": "title",
+			"value": {
+				"field": "someField",
+				"mapper": {
+					"name": "suffix",
+					"props": {
+						"addWhitespace": true,
+						"value": "hs"
+					}
+				}
+			},
+			"percent": {
+				"field": "someField",
+				"mapper": {
+					"name": "suffix",
+					"props": {
+						"addWhitespace": true,
+						"value": "%"
+					}
+				}
+			},
+			"x": 0,
+			"y": 0,
+			"width": 12,
+			"height": 4,
+			"link": "/test"
+		},
+		{
+			"component": "TextCardKpi",
+			"filters": [],
+			"name": "TextCardDelivery",
+			"title": "title",
+			"value": {
+				"field": "someField",
+				"mapper": {
+					"name": "suffix",
+					"props": {
+						"addWhitespace": true,
+						"value": "hs"
+					}
+				}
+			},
+			"percent": {
+				"field": "someField",
+				"mapper": {
+					"name": "suffix",
+					"props": {
+						"addWhitespace": true,
+						"value": "%"
+					}
+				}
+			},
+			"x": 0,
+			"y": 0,
+			"width": 12,
+			"height": 4
+		}
+	]
+}

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -163,7 +163,7 @@ describe('Test validation functions', () => {
 		const planningData = Validator.execute(planningSchema, true, '/test/data17.json');
 		const settingsData = Validator.execute(settingsSchema, true, '/test/data18.json');
 		const dashboardWithSourcesData = Validator.execute(dashboardWithSourcesSchema, true, '/test/data19.json');
-		const dashboardWithLinksData = Validator.execute(dashboardWithLinksSchema, true, '/test/data19.json');
+		const dashboardWithLinksData = Validator.execute(dashboardWithLinksSchema, true, '/test/data20.json');
 
 		sinon.assert.match(browseData, JSON.parse(browseSchemaExpectedJson.toString()));
 		sinon.assert.match(browseWithCanCreateData, JSON.parse(browseWithCanCreateSchemaExpectedJson.toString()));

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -41,6 +41,8 @@ const dashboardSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas
 const dashboardSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/dashboard.json');
 const dashboardWithSourcesSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/dashboard-with-sources.yml');
 const dashboardWithSourcesSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/dashboard-with-sources.json');
+const dashboardWithLinksSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/dashboard-with-links.json');
+const dashboardWithLinksSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/dashboard-with-links.yml');
 const previewSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/preview.yml');
 const previewSchemaExpected = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/preview.json');
 const sectionExampleYML = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/section-example.yml');
@@ -131,6 +133,7 @@ describe('Test validation functions', () => {
 		const newWithRedirectSchema = ymljs.parse(newWithRedirectSchemaYml.toString());
 		const dashboardSchema = ymljs.parse(dashboardSchemaYml.toString());
 		const dashboardWithSourcesSchema = ymljs.parse(dashboardWithSourcesSchemaYml.toString());
+		const dashboardWithLinksSchema = ymljs.parse(dashboardWithLinksSchemaYml.toString());
 		const previewSchema = ymljs.parse(previewSchemaYml.toString());
 		const sectionSchema = ymljs.parse(sectionExampleYML.toString());
 		const settingsSchema = ymljs.parse(settingsYML.toString());
@@ -160,6 +163,7 @@ describe('Test validation functions', () => {
 		const planningData = Validator.execute(planningSchema, true, '/test/data17.json');
 		const settingsData = Validator.execute(settingsSchema, true, '/test/data18.json');
 		const dashboardWithSourcesData = Validator.execute(dashboardWithSourcesSchema, true, '/test/data19.json');
+		const dashboardWithLinksData = Validator.execute(dashboardWithLinksSchema, true, '/test/data19.json');
 
 		sinon.assert.match(browseData, JSON.parse(browseSchemaExpectedJson.toString()));
 		sinon.assert.match(browseWithCanCreateData, JSON.parse(browseWithCanCreateSchemaExpectedJson.toString()));
@@ -179,6 +183,7 @@ describe('Test validation functions', () => {
 		sinon.assert.match(newWithRedirectData, JSON.parse(newWithRedirectSchemaExpectedJson.toString()));
 		sinon.assert.match(dashboardData, JSON.parse(dashboardSchemaExpectedJson.toString()));
 		sinon.assert.match(dashboardWithSourcesData, JSON.parse(dashboardWithSourcesSchemaExpectedJson.toString()));
+		sinon.assert.match(dashboardWithLinksData, JSON.parse(dashboardWithLinksSchemaExpectedJson.toString()));
 		sinon.assert.match(previewData, JSON.parse(previewSchemaExpected.toString()));
 		sinon.assert.match(sectionData, JSON.parse(sectionExampleExpected.toString()));
 		sinon.assert.match(settingsData, JSON.parse(settingsExpected.toString()));


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3718
## Descripción del requerimiento
Se requiere agregar la key link de tipo string a los Chart (graph) de dashboard
## Descripción de la solución
- Se agrego la key link de tipo string a graphs de dashboard y se agregaron los test necesarios para probarlo
## Cómo se puede probar?
- Verificar los test nuevos y ver que todos los tipos de graph tienen link y un TextCardKpi repetido no lo tiene para validar que funcione sin link
- Correr npm run test 
- Luego ir jugando con la key link probando otros tipos y quitandolo de los distintos graphs y ver que todo funcione bien corriendo npm run test las veces necesarias
## Link a la documentación
-
## Datos extra a tener en cuenta
-
## Changelog
```
### Added
- Link key to dashboard graphs
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
