### PR TITLE
add browseSection to setting posibilities at sections

### DIFF
--- a/lib/schemas/settings/modules/sectionNames.js
+++ b/lib/schemas/settings/modules/sectionNames.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = ['FormSection', 'MultiSection', 'RemoteSection'];
+module.exports = ['FormSection', 'MultiSection', 'RemoteSection', 'BrowseSection'];


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3657
## Descripción del requerimiento
- Permitir que a las secciones de la vista Settings, se le pueda pasar un BrowseSection
## Descripción de la solución
- Se agregó la key en las permitidas
## Cómo se puede probar?
- Ingresando a la rama y corriendo el comando npm run test
- Agregando un browse section en el mock de settings tanto en json como en yml

## Changelog
```
### Added
BrowseSection at settings
- 
### Changed
- 
### Fixed
- 
### Deprecated
- 
### Removed
- 
```
