### PR TITLE
cansselecrtAll at multiselects

### DIFF
--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -16,6 +16,7 @@ module.exports = makeComponent({
 		responseProperty: { type: 'string' },
 		translateGroupLabel: { type: 'boolean' },
 		imageField: { type: 'string' },
+		canSelectAll: { type: 'boolean' },
 		options: {
 			type: 'object',
 			properties: {

--- a/lib/schemas/browse/modules/filters/filters.js
+++ b/lib/schemas/browse/modules/filters/filters.js
@@ -35,7 +35,29 @@ module.exports = {
 				]
 			}
 		},
-		allOf: filterComponents,
+		allOf: [
+			...filterComponents,
+			{
+				if: {
+					properties: {
+						component: { const: 'Select' }
+					}
+				},
+				then: {
+					not: {
+						properties: {
+							componentAttributes: {
+								properties: {
+									canSelectAll: { type: 'boolean' }
+								},
+								required: ['canSelectAll']
+							}
+						},
+						required: ['componentAttributes']
+					}
+				}
+			}
+		],
 		additionalProperties: false,
 		required: ['component', 'name']
 	},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -678,6 +678,7 @@
       "name": "remoteMultiselect",
       "component": "Multiselect",
       "componentAttributes": {
+        "canSelectAll": true,
         "translateLabels": true,
         "imageField": "imageUrl",
         "options": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -743,6 +743,7 @@
 			"name": "remoteMultiselect",
 			"component": "Multiselect",
 			"componentAttributes": {
+				"canSelectAll": true,
 				"translateLabels": true,
 				"imageField": "imageUrl",
 				"options": {


### PR DESCRIPTION
## Link al ticket
-  https://janiscommerce.atlassian.net/browse/JMV-3832
## Descripción del requerimiento
- Se necesita agregar a los Multiselect de filtros el atributo canSelectAll, es booleano
## Descripción de la solución
- Se agregó la key al select
- se valido desde el componente del filtro para poder acceder a los component atrtributes y al nombre del componente
- Se agregaron casos en los schemas de browse

## Cómo se puede probar?
- Ingresando a la rama
- Corriendo el comando `npm run test`
Se agrego un caso en `browse.json` y `expected/browse.json`
## Changelog
```
### Added
- New canSelectAll at filter multiSelect
```
