### PR TITLE
Added key verifiedAddressField to Location and tests

### DIFF
--- a/lib/schemas/edit-new/modules/components/location.js
+++ b/lib/schemas/edit-new/modules/components/location.js
@@ -23,6 +23,9 @@ module.exports = makeComponent({
 			},
 			minProperties: 2,
 			additionalProperties: false
+		},
+		verifiedAddressField: {
+			type: 'string'
 		}
 	},
 	requiredProperties: ['label']

--- a/tests/mocks/schemas/edit-with-actions.yml
+++ b/tests/mocks/schemas/edit-with-actions.yml
@@ -806,6 +806,7 @@ sections:
                         - - name: isNotEmpty
                             field: order
                   - country
+              verifiedAddressField: address
 
           - name: asyncWrapperExampleOne
             component: AsyncWrapper

--- a/tests/mocks/schemas/expected/edit-with-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-actions.json
@@ -1300,7 +1300,8 @@
 										},
 										"country"
 									]
-								}
+								},
+								"verifiedAddressField": "address"
 							}
 						},
 						{


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3844
## Descripción del requerimiento
- Se necesita agregar la key verifiedAddressField al componente Location en sus componentAttributes
## Descripción de la solución
- Se agregó la key verifiedAddressField al componente Location en sus componentAttributes
- Se agrego el uso de la key verifiedAddressField en test
- se actualizo la [docu](https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2243035236/Location) del componente

## Cómo se puede probar?
- Ingresando a la rama
- Corriendo el comando `npm run test`
- Tambien probar cambiando el tipo de valor que recibe verifiedAddressField a object, array, number, etc y debe romper los tests
- Luego quitar la key y debe funcionar bien
Se agrego un caso en `edit-with-actions.json`
## Changelog
```
### Added
- New key verifiedAddressField in Location component
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional "verified address" field in location components, allowing enhanced address verification capabilities where configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->