### PR TITLE
Added behavior to massiveActions and ActionButtons

### DIFF
--- a/lib/schemas/common/actions/action.js
+++ b/lib/schemas/common/actions/action.js
@@ -24,6 +24,13 @@ module.exports = {
 		options: {
 			type: 'object',
 			default: {}
+		},
+		behavior: {
+			type: 'object',
+			properties: {
+				status: { type: 'string' },
+				statusMotive: { type: 'string' }
+			}
 		}
 	},
 	if: {

--- a/lib/schemas/common/actions/action.js
+++ b/lib/schemas/common/actions/action.js
@@ -28,7 +28,7 @@ module.exports = {
 		behavior: {
 			type: 'object',
 			properties: {
-				status: { type: 'string' },
+				status: { enum: ['blocked'] },
 				statusMotive: { type: 'string' }
 			}
 		}

--- a/lib/schemas/common/generic-actions/action.js
+++ b/lib/schemas/common/generic-actions/action.js
@@ -23,6 +23,13 @@ module.exports = {
 			type: 'array',
 			items: { type: 'string' },
 			minItems: 1
+		},
+		behavior: {
+			type: 'object',
+			properties: {
+				status: { type: 'string' },
+				statusMotive: { type: 'string' }
+			}
 		}
 	},
 	allOf: [

--- a/lib/schemas/common/generic-actions/action.js
+++ b/lib/schemas/common/generic-actions/action.js
@@ -27,7 +27,7 @@ module.exports = {
 		behavior: {
 			type: 'object',
 			properties: {
-				status: { type: 'string' },
+				status: { enum: ['blocked'] },
 				statusMotive: { type: 'string' }
 			}
 		}

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -170,6 +170,10 @@
 				"name": "testEndpoint",
 				"type": "endpoint",
 				"callback": "refresh",
+				"behavior": {
+					"status": "blocked",
+					"statusMotive": "motive"
+				},
 				"componentAttributes": {
 					"icon": "box",
 					"endpoint": {

--- a/tests/mocks/schemas/edit-with-actions.yml
+++ b/tests/mocks/schemas/edit-with-actions.yml
@@ -193,6 +193,9 @@ sections:
             icon: star_light
             color: fizzGreen
             type: link
+            behavior:
+              status: blocked
+              statusMotive: motive
             options:
               target:
                 service: serviceName

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -217,6 +217,10 @@
 				"name": "testEndpoint",
 				"type": "endpoint",
 				"callback": "refresh",
+				"behavior": {
+					"status": "blocked",
+					"statusMotive": "motive"
+				},
 				"componentAttributes": {
 					"icon": "box",
 					"endpoint": {

--- a/tests/mocks/schemas/expected/edit-with-actions.json
+++ b/tests/mocks/schemas/expected/edit-with-actions.json
@@ -302,6 +302,10 @@
 							"icon": "star_light",
 							"color": "fizzGreen",
 							"type": "link",
+							"behavior": {
+								"status": "blocked",
+								"statusMotive": "motive"
+							},	
 							"options": {
 								"target": {
 									"service": "serviceName",


### PR DESCRIPTION
## Link al ticket
https://janiscommerce.atlassian.net/browse/JMV-3841
## Descripción del requerimiento
- Se necesita agregar la key behavior con los campos internos status (string) que debe ser un enum donde se permita solo "blocked" y statusMotive (string) a los componentes generic-actions que afecta a massiveActions y actions que afecta a ActionButton 
## Descripción de la solución
- Se agrego behavior a generic-actions
- Se agrego behavior a actions
- Se actualizo la de [RemoveActions](https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2237792271/RemoteActions) y [GenericActions](https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2219507932/GenericActions) 
## Cómo se puede probar?
- Ingresando a la rama
- Corriendo el comando `npm run test`
- Tambien probar poniendo otros status no permitidos y quitando y poniendo en otros actions la key y viendo que funcione bien
Se agrego un caso en `browse.json` y en `edit-with-actions.json`
## Evidencia
Al poner un status no valido rompe
<img width="1457" height="727" alt="image" src="https://github.com/user-attachments/assets/67866a47-2844-469a-8d1a-47048300d17a" />
Al poner status valido va bien y no es requerido ya que otros actions no la tienen y no rompen los tests
<img width="1457" height="805" alt="image" src="https://github.com/user-attachments/assets/5ca09124-19ca-473d-9cec-1376ce4a0615" />

## Changelog
```
### Added
- New key behavior to generic-actions and actions
```