### PR TITLE
add new format at numberToTime mapper

### DIFF
--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -22,7 +22,14 @@ const baseMapperSchema = [
 					properties: {
 						type: {
 							type: 'string',
-							enum: ['minute', 'hour', 'day', 'week'],
+							oneOf: [
+								{
+									enum: ['minute', 'hour', 'day', 'week']
+								},
+								{
+									pattern: '^([H]{1,2}|[m]{1,2}|[s]{1,2})(:([H]{1,2}|[m]{1,2}|[s]{1,2}))*$'
+								}
+							],
 							default: 'hour'
 						}
 					},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -1330,7 +1330,7 @@
 			"mapper": {
 				"name": "numberToTime",
 				"props": {
-					"type": "hour"
+					"type": "HH:mm:ss"
 				}
 			}
 		},

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -1693,7 +1693,7 @@
 			"mapper": {
 				"name": "numberToTime",
 				"props": {
-					"type": "hour"
+					"type": "HH:mm:ss"
 				}
 			},
 			"attributes": {


### PR DESCRIPTION
## Link al ticket
- https://janiscommerce.atlassian.net/browse/JMV-3878

## Descripción del requerimiento

- Se requiere agregar soporte para un nuevo formato de tiempo en el mapper `numberToTime` que permita especificar formatos personalizados usando patrones como `HH:mm:ss`, `mm:ss`, `H:m:s`, etc.

## Criterios de aprobación

- El mapper `numberToTime` debe aceptar tanto los formatos existentes (`minute`, `hour`, `day`, `week`) como los nuevos formatos personalizados
- Los nuevos formatos deben seguir el patrón `^([H]{1,2}|[m]{1,2}|[s]{1,2})(:([H]{1,2}|[m]{1,2}|[s]{1,2}))*$`, es decir, permite los valores `H`, `m` y `s`, en un máximo de 2 veces cada uno (no permite `HHH`)
- Los tests deben pasar correctamente

## Descripción de la solución

- Se modificó el esquema de validación en `lib/schemas/common/mapper.js` para el mapper `numberToTime`
- Se cambió la propiedad `type` de un simple `enum` a un `oneOf` que permite:
  1. Los valores originales: `['minute', 'hour', 'day', 'week']`
  2. Un nuevo patrón regex que acepta formatos como `HH:mm:ss`, `mm:ss`, `H:m:s`, etc.
- Se actualizaron los archivos de test para incluir un caso de prueba con el nuevo formato `HH:mm:ss`
- Se mantiene el valor por defecto `hour` para preservar la compatibilidad

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
|--------------|-------------------|-------------------|---------------|
| Validar esquema con formato original "hour" | Debe ser válido | ✅ | Compatibilidad hacia atrás |
| Validar esquema con formato original "minute" | Debe ser válido | ✅ | Compatibilidad hacia atrás |
| Validar esquema con formato original "day" | Debe ser válido | ✅ | Compatibilidad hacia atrás |
| Validar esquema con formato original "week" | Debe ser válido | ✅ | Compatibilidad hacia atrás |
| Validar esquema con nuevo formato "HH:mm:ss" | Debe ser válido | ✅ | Nuevo formato agregado |
| Validar esquema con nuevo formato "mm:ss" | Debe ser válido | ✅ | Nuevo formato agregado |
| Validar esquema con nuevo formato "H:m:s" | Debe ser válido | ✅ | Nuevo formato agregado |
| Validar esquema con formato inválido "HHH:m:ss" | Debe ser inválido | ✅ | Validación correcta |
| Ejecutar suite completa de tests | Todos los tests deben pasar | ✅ | 60 tests pasando |

## Evidencias, pruebas de cómo funciona
<img width="652" height="183" alt="image" src="https://github.com/user-attachments/assets/272a8fba-a783-48ca-a13c-c8371acf6b5b" />

## DOCUMENTACION
https://janiscommerce.atlassian.net/wiki/spaces/JMV/pages/2219671665/Mappers#Descripci%C3%B3n.1

## CHANGELOG:

```javascript
### Added
- Support for custom time formats in numberToTime mapper using patterns like HH:mm:ss, mm:ss, H:m:s [JMV-3878](https://janiscommerce.atlassian.net/browse/JMV-3878)
```

[JMV-3878]: https://janiscommerce.atlassian.net/browse/JMV-3878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded time formatting support for number-to-time mapping. In addition to minute/hour/day/week, you can now use token-based formats (e.g., H, HH:mm, HH:mm:ss). Default remains hour.
* **Tests**
  * Updated mock schemas and expected outputs to use HH:mm:ss, validating the new time format support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->