### PR TITLE
Jmv 3878 add new format validator

### DIFF
--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -22,7 +22,14 @@ const baseMapperSchema = [
 					properties: {
 						type: {
 							type: 'string',
-							enum: ['minute', 'hour', 'day', 'week'],
+							oneOf: [
+								{
+									enum: ['minute', 'hour', 'day', 'week']
+								},
+								{
+									pattern: '^([H]{1,2}|[m]{1,2}|[s]{1,2})(:([H]{1,2}|[m]{1,2}|[s]{1,2}))*$'
+								}
+							],
 							default: 'hour'
 						}
 					},

--- a/lib/schemas/common/mapper.js
+++ b/lib/schemas/common/mapper.js
@@ -22,15 +22,11 @@ const baseMapperSchema = [
 					properties: {
 						type: {
 							type: 'string',
-							oneOf: [
-								{
-									enum: ['minute', 'hour', 'day', 'week']
-								},
-								{
-									pattern: '^([H]{1,2}|[m]{1,2}|[s]{1,2})(:([H]{1,2}|[m]{1,2}|[s]{1,2}))*$'
-								}
-							],
-							default: 'hour'
+							enum: ['minute', 'hour', 'day', 'week']
+						},
+						format: {
+							type: 'string',
+							pattern: '^([H]{1,2}|[m]{1,2}|[s]{1,2})(:([H]{1,2}|[m]{1,2}|[s]{1,2}))*$'
 						}
 					},
 					additionalProperties: false

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -1330,7 +1330,8 @@
 			"mapper": {
 				"name": "numberToTime",
 				"props": {
-					"type": "HH:mm:ss"
+					"type": "hour",
+					"format": "HH:mm:ss"
 				}
 			}
 		},

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -1330,7 +1330,7 @@
 			"mapper": {
 				"name": "numberToTime",
 				"props": {
-					"type": "hour"
+					"type": "HH:mm:ss"
 				}
 			}
 		},

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -1693,7 +1693,8 @@
 			"mapper": {
 				"name": "numberToTime",
 				"props": {
-					"type": "HH:mm:ss"
+					"type": "hour",
+					"format": "HH:mm:ss"
 				}
 			},
 			"attributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -1693,7 +1693,7 @@
 			"mapper": {
 				"name": "numberToTime",
 				"props": {
-					"type": "hour"
+					"type": "HH:mm:ss"
 				}
 			},
 			"attributes": {


### PR DESCRIPTION
## Link al ticket

- [JMV-3878](https://janiscommerce.atlassian.net/browse/JMV-3878)

## Descripción del requerimiento

- Refactorización del mapper `numberToTime` para separar la propiedad `type` de la propiedad `format`, permitiendo una configuración más clara y flexible del formato de tiempo.

## Criterios de aprobación

- El mapper `numberToTime` debe mantener la compatibilidad con las propiedades `type` (minute, hour, day, week)
- Se debe agregar una nueva propiedad `format` con validación de patrón para formatos de tiempo personalizados
- Los tests deben pasar correctamente
- Se debe eliminar código obsoleto relacionado con mappers no utilizados

## Descripción de la solución

- Se refactorizó el esquema del mapper `numberToTime` en `lib/schemas/common/mapper.js`:
  - Se separó la propiedad `type` (que mantiene los valores enum: minute, hour, day, week)
  - Se agregó una nueva propiedad `format` con validación de patrón para formatos de tiempo como 'HH:mm:ss', 'mm:ss', etc.
  - Se eliminó el mapper `deliveryDate` que no estaba siendo utilizado
  - Se limpiaron archivos de test obsoletos relacionados con mappers
- Se actualizaron los archivos de test para reflejar la nueva estructura del mapper
- Se eliminaron referencias a archivos de test que ya no existen

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
|--------------|-------------------|-------------------|---------------|
| Validar esquema con mapper numberToTime usando solo type | Debe validar correctamente con valores: minute, hour, day, week | ✅ | Funciona como antes |
| Validar esquema con mapper numberToTime usando solo format | Debe validar correctamente con formatos como 'HH:mm:ss', 'mm:ss' | ✅ | Nueva funcionalidad |
| Validar esquema con mapper numberToTime usando type y format | Debe validar correctamente ambas propiedades | ✅ | Combinación válida |
| Validar esquema con mapper numberToTime sin propiedades | Debe fallar la validación | ✅ | Validación correcta |
| Ejecutar tests completos | Todos los tests deben pasar | ✅ | Suite de tests exitosa |

**Notas de configuración:**
- Ejecutar `npm run test` para verificar que todos los tests pasen ya que hay un caso aplicado
- Vwerificar que no permita poner mas letras que 2 de cada una

## Evidencias, pruebas de cómo funciona

- Los tests en `tests/validator-test.js` validan correctamente la nueva estructura del mapper
- El archivo `tests/mocks/schemas/browse.json` muestra un ejemplo de uso con `type: "hour"` y `format: "HH:mm:ss"`
- Los archivos de test esperados reflejan la nueva estructura del mapper
- La validación del esquema funciona correctamente con ambos tipos de configuración

## CHANGELOG:

```javascript
### Changed
- Refactored `numberToTime` mapper to separate `type` and `format` properties for better clarity and flexibility [JMV-3878](https://janiscommerce.atlassian.net/browse/JMV-3878)

### Removed
- Removed unused `deliveryDate` mapper and related test files [JMV-3878](https://janiscommerce.atlassian.net/browse/JMV-3878)
```

---