### PR TITLE
Jmv 3898 add theme conditionals at validator

### DIFF
--- a/lib/schemas/browse/modules/components/chips.js
+++ b/lib/schemas/browse/modules/components/chips.js
@@ -92,7 +92,8 @@ const chipComponents = [
 			translateLabels: { type: 'boolean', default: false },
 			borderColor: { type: 'string', default: 'blue' },
 			background: { type: 'string', default: 'white' },
-			color: { type: 'string', default: 'blue' }
+			color: { type: 'string', default: 'blue' },
+			themeConditionals
 		}
 	}
 ];

--- a/lib/schemas/edit-new/modules/componentNames.js
+++ b/lib/schemas/edit-new/modules/componentNames.js
@@ -17,6 +17,7 @@ module.exports = {
 	userChip: 'UserChip',
 	statusChip: 'StatusChip',
 	mediumChip: 'MediumChip',
+	smallChip: 'SmallChip',
 	code: 'Code',
 	dateTimePicker: 'DateTimePicker',
 	newDatePicker: 'NewDatePicker',

--- a/lib/schemas/edit-new/modules/components/chips.js
+++ b/lib/schemas/edit-new/modules/components/chips.js
@@ -5,7 +5,13 @@ const { conditionsSchema } = require('../../../common/conditions/conditions');
 const { makeComponent } = require('../../../utils');
 const link = require('../../../common/link');
 
-const { chip, userChip, statusChip, mediumChip } = componentNames;
+const {
+	chip,
+	userChip,
+	statusChip,
+	mediumChip,
+	smallChip
+} = componentNames;
 
 const themeProps = {
 	oneOf: [
@@ -74,6 +80,16 @@ const chipComponents = [
 			themeConditionals,
 			linkField: { type: 'string' },
 			...link.properties
+		}
+	},
+	{
+		name: smallChip,
+		properties: {
+			translateLabels: { type: 'boolean', default: false },
+			borderColor: { type: 'string', default: 'blue' },
+			background: { type: 'string', default: 'white' },
+			color: { type: 'string', default: 'blue' },
+			themeConditionals
 		}
 	}
 ];


### PR DESCRIPTION
## Link al ticket

- [JMV-3898](https://janiscommerce.atlassian.net/browse/JMV-3898)

## Descripción del requerimiento

- Agregar soporte para `themeConditionals` en el componente `smallChip` para permitir la aplicación condicional de temas basados en diferentes condiciones
- Incluir `smallChip` como componente válido en los esquemas de validación para las vistas de edit y new
- Extender la funcionalidad de chips para soportar configuraciones de tema condicionales

## Criterios de aprobación

- El componente `smallChip` debe soportar la propiedad `themeConditionals`
- Los esquemas de validación deben incluir `smallChip` como componente válido
- La funcionalidad debe mantener compatibilidad con componentes existentes
- Los tests deben pasar correctamente

## Descripción de la solución

- Se agregó la propiedad `themeConditionals` al componente `smallChip` en los esquemas de browse y edit-new
- Se incluyó `smallChip` en la lista de nombres de componentes válidos (`componentNames.js`)
- Se definió la estructura de `themeConditionals` como un objeto que acepta condiciones como propiedades adicionales
- Se mantuvo la consistencia con otros componentes de chips existentes como `statusChip` y `mediumChip`

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
|--------------|-------------------|-------------------|---------------|
| Validar esquema con smallChip sin themeConditionals | Debe validar correctamente | ✅ o ❌ | Componente debe funcionar con propiedades básicas |
| Validar esquema con smallChip con themeConditionals | Debe validar correctamente | ✅ o ❌ | Debe aceptar objeto con condiciones como propiedades |
| Validar esquema con smallChip en vista edit | Debe reconocer smallChip como componente válido | ✅ o ❌ | Debe aparecer en la lista de componentes disponibles |
| Validar esquema con smallChip en vista browse | Debe reconocer smallChip como componente válido | ✅ o ❌ | Debe aparecer en la lista de componentes disponibles |
| Validar esquema con themeConditionals inválido | Debe fallar la validación | ✅ o ❌ | Debe rechazar objetos vacíos o con estructura incorrecta |

## Evidencias, pruebas de cómo funciona

- Los cambios se implementaron en los archivos de esquemas de validación
- Se agregó soporte para `themeConditionals` manteniendo la estructura existente
- El componente `smallChip` ahora está disponible tanto en browse como en edit/new

## Datos extra a tener en cuenta

- Los cambios mantienen compatibilidad hacia atrás con componentes existentes
- La implementación sigue el mismo patrón usado en otros componentes de chips
- Se utilizó la misma estructura de `themeConditionals` que ya existía en el proyecto

## CHANGELOG (English only):

```javascript
### Added
- Added `themeConditionals` support to `smallChip` component in browse and edit-new schemas
- Added `smallChip` to valid component names for edit and new views
```

---

[JMV-3898]: https://janiscommerce.atlassian.net/browse/JMV-3898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ