### PR TITLE
Jmv 4017 validate mixed select schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.16.0] - 2026-06-03
+
+### Added
+
+- Common remote options schema
+- localValues at remote options
+
 ## [3.15.0] - 2026-05-28
 
 ### Added

--- a/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
+++ b/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
@@ -1,50 +1,6 @@
 'use strict';
 
 const getEndpointParameters = require('../../../../../common/endpointParameters');
+const getRemoteOptions = require('../../../../../common/remoteOptions');
 
-module.exports = {
-	if: {
-		properties: {
-			scope: { const: 'remote' }
-		}
-	},
-	then: {
-		properties: {
-			scope: { const: 'remote' },
-			endpoint: {
-				$ref: 'schemaDefinitions#/definitions/endpoint'
-			},
-			initialValuesEndpoint: {
-				oneOf: [
-					{ $ref: 'schemaDefinitions#/definitions/endpoint' },
-					{ const: false }
-				]
-			},
-			initialValuesFilterName: { type: 'string' },
-			initialValuesPathParam: { type: 'string' },
-			searchParam: { type: 'string', default: 'filters[search]' },
-			endpointParameters: getEndpointParameters(true),
-			valuesMapper: {
-				type: 'object',
-				properties: {
-					label: {
-						oneOf: [
-							{ type: 'string' },
-							{ $ref: 'schemaDefinitions#/definitions/template' }
-						]
-					},
-					value: { type: 'string' }
-				},
-				default: {
-					label: 'name',
-					value: 'id'
-				},
-				required: ['label', 'value'],
-				additionalProperties: false
-			},
-			groupField: { type: 'string' }
-		},
-		required: ['endpoint'],
-		additionalProperties: false
-	}
-};
+module.exports = getRemoteOptions(getEndpointParameters(true));

--- a/lib/schemas/common/remoteOptions.js
+++ b/lib/schemas/common/remoteOptions.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Schema condicional compartido para options con scope === 'remote' (Select/Multiselect).
+ * Cada consumidor (edit-new, browse filters) inyecta su propio endpointParameters.
+ * @param {object} endpointParametersSchema - Definición de endpointParameters (ref o getEndpointParameters(...))
+ * @returns {{ if: object, then: object }}
+ */
+function getRemoteOptions(endpointParametersSchema) {
+	return {
+		if: {
+			properties: {
+				scope: { const: 'remote' }
+			}
+		},
+		then: {
+			properties: {
+				scope: { const: 'remote' },
+				endpoint: {
+					$ref: 'schemaDefinitions#/definitions/endpoint'
+				},
+				initialValuesEndpoint: {
+					oneOf: [
+						{ $ref: 'schemaDefinitions#/definitions/endpoint' },
+						{ const: false }
+					]
+				},
+				initialValuesFilterName: { type: 'string' },
+				initialValuesPathParam: { type: 'string' },
+				searchParam: { type: 'string', default: 'filters[search]' },
+				endpointParameters: endpointParametersSchema,
+				valuesMapper: {
+					type: 'object',
+					properties: {
+						label: {
+							oneOf: [
+								{ type: 'string' },
+								{ $ref: 'schemaDefinitions#/definitions/template' }
+							]
+						},
+						value: { type: 'string' }
+					},
+					default: {
+						label: 'name',
+						value: 'id'
+					},
+					required: ['label', 'value'],
+					additionalProperties: false
+				},
+				groupField: { type: 'string' },
+				localValues: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							value: { type: 'string' },
+							label: { type: 'string' }
+						},
+						required: ['value', 'label'],
+						additionalProperties: false
+					}
+				}
+			},
+			required: ['endpoint'],
+			additionalProperties: false
+		}
+	};
+}
+
+module.exports = getRemoteOptions;

--- a/lib/schemas/edit-new/modules/options/remoteOptions.js
+++ b/lib/schemas/edit-new/modules/options/remoteOptions.js
@@ -1,48 +1,7 @@
 'use strict';
 
-module.exports = {
-	if: {
-		properties: {
-			scope: { const: 'remote' }
-		}
-	},
-	then: {
-		properties: {
-			scope: { const: 'remote' },
-			endpoint: {
-				$ref: 'schemaDefinitions#/definitions/endpoint'
-			},
-			initialValuesEndpoint: {
-				oneOf: [
-					{ $ref: 'schemaDefinitions#/definitions/endpoint' },
-					{ const: false }
-				]
-			},
-			initialValuesFilterName: { type: 'string' },
-			initialValuesPathParam: { type: 'string' },
-			searchParam: { type: 'string', default: 'filters[search]' },
-			endpointParameters: { $ref: 'schemaDefinitions#/definitions/endpointParameters' },
-			valuesMapper: {
-				type: 'object',
-				properties: {
-					label: {
-						oneOf: [
-							{ type: 'string' },
-							{ $ref: 'schemaDefinitions#/definitions/template' }
-						]
-					},
-					value: { type: 'string' }
-				},
-				default: {
-					label: 'name',
-					value: 'id'
-				},
-				required: ['label', 'value'],
-				additionalProperties: false
-			},
-			groupField: { type: 'string' }
-		},
-		required: ['endpoint'],
-		additionalProperties: false
-	}
-};
+const getRemoteOptions = require('../../../common/remoteOptions');
+
+module.exports = getRemoteOptions({
+	$ref: 'schemaDefinitions#/definitions/endpointParameters'
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@janiscommerce/view-schema-validator",
-	"version": "3.14.0",
+	"version": "3.16.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@janiscommerce/view-schema-validator",
-	"version": "3.14.0",
+	"version": "3.16.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/tests/mocks/schemas/browse-countDown.json
+++ b/tests/mocks/schemas/browse-countDown.json
@@ -612,7 +612,10 @@
 							]
 						},
 						"value": "id"
-					}
+					},
+					"localValues": [
+						{ "value": "sin_asignacion", "label": "Sin asignación" }
+					]
 				}
 			}
 		},

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1078,6 +1078,9 @@ sections:
                 valuesMapper:
                   label: name
                   value: id
+                localValues:
+                  - value: sin_asignacion
+                    label: Sin asignación
 
           - name: selectRemoteTwo
             component: Select

--- a/tests/mocks/schemas/expected/browse-countDown.json
+++ b/tests/mocks/schemas/expected/browse-countDown.json
@@ -632,7 +632,10 @@
 							]
 						},
 						"value": "id"
-					}
+					},
+					"localValues": [
+						{ "value": "sin_asignacion", "label": "Sin asignación" }
+					]
 				}
 			}
 		},

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1706,7 +1706,10 @@
                   "valuesMapper": {
                     "label": "name",
                     "value": "id"
-                  }
+                  },
+                  "localValues": [
+                    { "value": "sin_asignacion", "label": "Sin asignación" }
+                  ]
                 }
               }
             },


### PR DESCRIPTION
## Link al ticket
[JMV-4017](https://janiscommerce.atlassian.net/browse/JMV-4017)

## Descripción del requerimiento
El validador de schemas de vistas Janis debe aceptar y validar la propiedad opcional `localValues` en componentes Select/Multiselect con `options.scope === 'remote'`. Además, el bloque condicional que define opciones remotas (endpoint, valuesMapper, localValues, etc.) estaba duplicado entre edit-new y browse filters, lo que se corrige centralizándolo en un módulo común.

## Descripción de la solución
- Se creó `lib/schemas/common/remoteOptions.js` con la función `getRemoteOptions(endpointParametersSchema)`, que devuelve el schema condicional para `scope === 'remote'` (endpoint, initialValuesEndpoint, endpointParameters, valuesMapper, localValues, etc.)
- Los módulos `lib/schemas/edit-new/modules/options/remoteOptions.js` y `lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js` dejan de duplicar ese bloque y pasan a usar `getRemoteOptions` con su propio schema de parámetros.
- Se añadió `localValues` en los mocks de prueba: en el filtro remoteSelect de `browse-countDown.json`, en el campo selectRemote de `edit.yml`, y en los expected `expected/browse-countDown.json` y `expected/edit.json`, de modo que el test "should schema builded is a expected" valide que el validador acepta y compila correctamente `localValues` en Select remoto.

## Cómo se puede probar?

| Caso | Resultado esperado | Resultado obtenido | Observaciones |
|------|--------------------|--------------------|---------------|
| Schema browse con filtro Select remoto incluyendo localValues | El schema compila y el JSON esperado incluye localValues en el filtro | Pendiente | browse-countDown.json / expected/browse-countDown.json |
| Schema edit con campo Select remoto incluyendo localValues | El schema compila y el JSON esperado incluye localValues en el campo | Pendiente | edit.yml / expected/edit.json |
| Schema con Select remoto sin localValues | Sigue siendo válido (localValues es opcional) | Pendiente | Comportamiento sin regresión |
| Tests unitarios del validador | Todos los tests pasan, incluido el que compara schema builded vs expected | Pendiente | `npm test` |


## Changelog
```
### Added
- Common remote options schema
- localValues at remote options

```


[JMV-4017]: https://janiscommerce.atlassian.net/browse/JMV-4017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Sin asignación" (No assignment) option to remote select fields in browse and edit modules.

* **Refactor**
  * Restructured remote options schema handling for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->