### PR TITLE
Jmv 4048 add to validate second lapse

### DIFF
--- a/lib/schemas/browse/modules/filters/components/dateTimePicker.js
+++ b/lib/schemas/browse/modules/filters/components/dateTimePicker.js
@@ -38,7 +38,7 @@ module.exports = makeComponent({
 			properties: {
 				hourLapse: { type: 'number' },
 				minuteLapse: { type: 'number' },
-				secondsLapse: { type: 'number' },
+				secondLapse: { type: 'number' },
 				custom: {
 					type: 'array',
 					items: {

--- a/lib/schemas/browse/modules/filters/components/dateTimePicker.js
+++ b/lib/schemas/browse/modules/filters/components/dateTimePicker.js
@@ -38,6 +38,7 @@ module.exports = makeComponent({
 			properties: {
 				hourLapse: { type: 'number' },
 				minuteLapse: { type: 'number' },
+				secondsLapse: { type: 'number' },
 				custom: {
 					type: 'array',
 					items: {

--- a/lib/schemas/common/fieldHelp.js
+++ b/lib/schemas/common/fieldHelp.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-	type: ['string', 'boolean']
+	type: 'string'
 };

--- a/lib/schemas/common/fieldHelp.js
+++ b/lib/schemas/common/fieldHelp.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-	type: 'string'
+	type: ['string', 'boolean']
 };

--- a/lib/schemas/edit-new/modules/components/dateTimePicker.js
+++ b/lib/schemas/edit-new/modules/components/dateTimePicker.js
@@ -38,7 +38,7 @@ module.exports = makeComponent({
 			properties: {
 				hourLapse: { type: 'number' },
 				minuteLapse: { type: 'number' },
-				secondsLapse: { type: 'number' },
+				secondLapse: { type: 'number' },
 				custom: {
 					type: 'array',
 					items: {

--- a/lib/schemas/edit-new/modules/components/dateTimePicker.js
+++ b/lib/schemas/edit-new/modules/components/dateTimePicker.js
@@ -38,6 +38,7 @@ module.exports = makeComponent({
 			properties: {
 				hourLapse: { type: 'number' },
 				minuteLapse: { type: 'number' },
+				secondsLapse: { type: 'number' },
 				custom: {
 					type: 'array',
 					items: {

--- a/lib/schemas/edit-new/modules/components/newDatePicker.js
+++ b/lib/schemas/edit-new/modules/components/newDatePicker.js
@@ -38,7 +38,7 @@ module.exports = makeComponent({
 			properties: {
 				hourLapse: { type: 'number' },
 				minuteLapse: { type: 'number' },
-				secondsLapse: { type: 'number' },
+				secondLapse: { type: 'number' },
 				custom: {
 					type: 'array',
 					items: {

--- a/lib/schemas/edit-new/modules/components/newDatePicker.js
+++ b/lib/schemas/edit-new/modules/components/newDatePicker.js
@@ -38,6 +38,7 @@ module.exports = makeComponent({
 			properties: {
 				hourLapse: { type: 'number' },
 				minuteLapse: { type: 'number' },
+				secondsLapse: { type: 'number' },
 				custom: {
 					type: 'array',
 					items: {

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1234,7 +1234,7 @@ sections:
               selectRange: true
               format: hh:mm:ss
               timeOptions:
-                secondsLapse: 10
+                secondLapse: 10
 
           - name: otherDateTime
             component: DateTimePicker

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -1224,6 +1224,17 @@ sections:
               selectRange: true
               format: hh:mm
 
+          - name: dateTimeSeconds
+            component: DateTimePicker
+            componentAttributes:
+              useTimezone: true
+              selectDate: false
+              selectTime: true
+              selectRange: true
+              format: hh:mm:ss
+              timeOptions:
+                secondsLapse: 10
+
           - name: otherDateTime
             component: DateTimePicker
             componentAttributes:

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -378,8 +378,7 @@ sections:
 
           - name: name
             component: CopyToClipboardButton
-            componentAttributes:
-              fieldHelp: true
+            componentAttributes: {}
 
           - name: svg
             component: Svg

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -378,7 +378,8 @@ sections:
 
           - name: name
             component: CopyToClipboardButton
-            componentAttributes: {}
+            componentAttributes:
+              fieldHelp: true
 
           - name: svg
             component: Svg

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -625,7 +625,9 @@
             {
               "name": "name",
               "component": "CopyToClipboardButton",
-              "componentAttributes": {}
+              "componentAttributes": {
+                "fieldHelp": true
+              }
             },
             {
               "name": "svg",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -625,9 +625,7 @@
             {
               "name": "name",
               "component": "CopyToClipboardButton",
-              "componentAttributes": {
-                "fieldHelp": true
-              }
+              "componentAttributes": {}
             },
             {
               "name": "svg",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1953,7 +1953,7 @@
                 "selectRange": true,
                 "format": "hh:mm:ss",
                 "timeOptions": {
-                  "secondsLapse": 10
+                  "secondLapse": 10
                 }
               }
             },

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -1942,6 +1942,20 @@
               }
             },
             {
+              "name": "dateTimeSeconds",
+              "component": "DateTimePicker",
+              "componentAttributes": {
+                "useTimezone": true,
+                "selectDate": false,
+                "selectTime": true,
+                "selectRange": true,
+                "format": "hh:mm:ss",
+                "timeOptions": {
+                  "secondsLapse": 10
+                }
+              }
+            },
+            {
               "name": "otherDateTime",
               "component": "DateTimePicker",
               "componentAttributes": {


### PR DESCRIPTION
## Link al ticket
- [JMV-4048] (https://janiscommerce.atlassian.net/browse/JMV-4048)

## Descripción del requerimiento
- Se necesita que los esquemas de validación acepten la propiedad numérica `secondsLapse` dentro de `timeOptions` en componentes de selección de fecha/hora, alineado con el uso en vistas Janis (intervalo de segundos en el picker)

## Descripción de la solución
- Se añadió `secondsLapse: { type: 'number' }` en `timeOptions.properties` en:
  - `lib/schemas/browse/modules/filters/components/dateTimePicker.js`
  - `lib/schemas/edit-new/modules/components/dateTimePicker.js`
  - `lib/schemas/edit-new/modules/components/newDatePicker.js`
- Cobertura de contrato en mocks: `tests/mocks/schemas/edit.yml` y `tests/mocks/schemas/expected/edit.json` (campo de ejemplo con `DateTimePicker`, `format: hh:mm:ss` y `timeOptions.secondsLapse: 10`)

## Cómo se puede probar?

Correr comando npm run test y validar que pasen todos
Agregar seconLapse combinado con minuteLapse y hourLapse para hacer pruebas

| Caso | Resultado esperado | Resultado obtenido | Observaciones |
|------|--------------------|-------------------|---------------|
| Ejecutar `npm run test-ci` en la rama, con `CHANGELOG.md` ya commiteado si corresponde | Suite completa en verde; cobertura generada por `nyc` sin errores de esquema en los mocks actualizados | Pendiente | Verificación local; no asumir resultado de CI remoto. |
| Ejecutar `npm test` (misma rama) | Mismos tests en verde (salida interactiva `nyan`) | Pendiente | Útil para iteración rápida; equivalente funcional a la corrida CI salvo reporter. |
| Validar un schema real que use `DateTimePicker` con `timeOptions.secondsLapse` numérico (flujo principal) | El validador acepta el schema; no aparece error por propiedad desconocida en `timeOptions` | Pendiente | Impacto directo en consumidores de `@janiscommerce/view-schema-validator`. |
| Caso límite: `secondsLapse` como número no entero o valor extremo según reglas de negocio de la vista | Comportamiento acorde a lo que la vista envía; el esquema solo tipa `number` | Pendiente | El cambio es de contrato JSON Schema, no de lógica de UI. |
| Caso negativo: `secondsLapse` con tipo incorrecto (p. ej. string) | La validación debe rechazar el schema | Pendiente | Confirma que el tipo declarado es `number`. |
| Validación visual / integración | N/A a nivel paquete: este repo valida esquemas, no renderiza componentes | Pendiente | Si aplica, probar en la app consumidora que el picker respeta el intervalo configurado. |


## Changelog
```
### Added
Se documenta y valida secondsLapse (número) dentro de timeOptions para DateTimePicker en browse (filtros) y en edit-new (dateTimePicker / newDatePicker) JMV-4048
```

[JMV-4048]: https://janiscommerce.atlassian.net/browse/JMV-4048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Date/time pickers now support seconds-level precision, enabling users to select times down to the second with customizable stepping intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->