### PR TITLE
Jmv 4034 boolean label description schema

### DIFF
--- a/lib/schemas/common/fieldHelp.js
+++ b/lib/schemas/common/fieldHelp.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-	type: 'string'
+	type: ['string', 'boolean']
 };

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -378,7 +378,8 @@ sections:
 
           - name: name
             component: CopyToClipboardButton
-            componentAttributes: {}
+            componentAttributes:
+              fieldHelp: true
 
           - name: svg
             component: Svg

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -625,7 +625,9 @@
             {
               "name": "name",
               "component": "CopyToClipboardButton",
-              "componentAttributes": {}
+              "componentAttributes": {
+                "fieldHelp": true
+              }
             },
             {
               "name": "svg",


### PR DESCRIPTION
## Link al ticket

- [JMV-4034](https://janiscommerce.atlassian.net/browse/JMV-4034)

## Descripción del requerimiento

En el paquete **@janiscommerce/view-schema-validator**, la definición compartida `fieldHelp` debía permitir valores **booleanos** además del **string** ya soportado, para alinear el JSON Schema con vistas que usan `fieldHelp` como flag (por ejemplo en `componentAttributes` de componentes generados con `makeComponent` y en campos edit-new). Se requiere cobertura en fixtures/mocks y en expectativas de tests donde se materializa el schema resuelto.

## Descripción de la solución

- **`lib/schemas/common/fieldHelp.js`**: `type` pasa de `'string'` a `['string', 'boolean']` (commit `80565ba`).
- **Fixtures**: `tests/mocks/schemas/edit.yml` incluye `fieldHelp: true` en un `CopyToClipboardButton`; `tests/mocks/schemas/expected/edit.json` actualizado en consecuencia (commit `94f43b0`).
- **`lib/schemas/utils.js` (`makeComponent`)** y **`lib/schemas/edit-new/modules/field.js`**: `fieldHelp` referenciado vía `$ref` a `schemaDefinitions#/definitions/fieldHelp` (contexto ya presente en la rama respecto a `master` local del entorno).
- **`tests/schema-utils-test.js`**: expectativas de `makeComponent` incluyen la propiedad `fieldHelp` con el `$ref` correspondiente.
- Otros archivos del diff contra `master` en este workspace (`CHANGELOG.md`, `assist.js`, `mainForm.js`, `formSection.js`, `definitions/index.js`, `package.json` / `package-lock.json`, `new.yml`, etc.) corresponden a la línea de commits ya fusionada en la rama (p. ej. versiones **3.11.0 / 3.12.0** y trabajo previo de `fieldHelp` / assist).

**Git / merge:** la rama hace tracking de `origin/JMV-4034-boolean-label-description-schema`. Hay **cambios sin commitear** en `package.json`: solo sube el **timeout de Mocha** de `8000` a `28000` en scripts `test`, `test-ci` y `watch-test`. Decidir si se **commitea** (útil si CI/local necesita más margen) o se **revierte** antes del merge para no mezclar con el alcance del ticket.

**CHANGELOG del repositorio:** la sección `## [Unreleased]` está vacía; `## [3.12.0] - 2026-04-21` documenta `fieldHelp` como string / integración en `makeComponent` y edit-new, **sin** mencionar `boolean`. Lo coherente con Keep a Changelog es **agregar bajo `[Unreleased]`** la entrada del boolean hasta que publiquen la siguiente versión (p. ej. **3.12.1** o **3.13.0**). Solo conviene **editar `[3.12.0]`** si esa versión **aún no salió a npm** y van a reetiquetar el mismo release con el boolean incluido.

## Cómo se puede probar?
- `npm run test`

## Changelog (sugerencia para pegar en `CHANGELOG.md` bajo `[Unreleased]` — inglés)

```text
### Changed
- Extended `fieldHelp` schema definition to accept `boolean` in addition to `string`. [JMV-4034](https://janiscommerce.atlassian.net/browse/JMV-4034)

[JMV-4034]: https://janiscommerce.atlassian.net/browse/JMV-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JMV-4034]: https://janiscommerce.atlassian.net/browse/JMV-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ