### PR TITLE
Jmv 4053 validate issearchable

### DIFF
--- a/lib/schemas/browse/modules/filter-components/select.js
+++ b/lib/schemas/browse/modules/filter-components/select.js
@@ -6,6 +6,7 @@ module.exports = makeComponent({
 	name: 'Select',
 	properties: {
 		translateLabels: { type: 'boolean', default: true },
+		isSearchable: { type: 'boolean' },
 		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		canClear: { type: 'boolean' },
 		options: {

--- a/lib/schemas/browse/modules/filters/components/select.js
+++ b/lib/schemas/browse/modules/filters/components/select.js
@@ -8,6 +8,7 @@ module.exports = makeComponent({
 	name: [select, multiselect],
 	properties: {
 		translateLabels: { type: 'boolean' },
+		isSearchable: { type: 'boolean' },
 		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		canClear: { type: 'boolean' },
 		canCreate: { type: 'boolean' },

--- a/lib/schemas/edit-new/modules/components/selects.js
+++ b/lib/schemas/edit-new/modules/components/selects.js
@@ -10,6 +10,7 @@ module.exports = makeComponent({
 	name: [select, multiselect],
 	properties: {
 		translateLabels: { type: 'boolean' },
+		isSearchable: { type: 'boolean' },
 		labelPrefix: { $ref: 'schemaDefinitions#/definitions/stringPrefix' },
 		labelFieldName: { type: 'string' },
 		canClear: { type: 'boolean' },

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -336,6 +336,7 @@ sections:
           - name: name
             component: Select
             componentAttributes:
+              isSearchable: true
               fieldHelp: Texto de ayuda visible en el tooltip.
               translateLabels: true
               labelFieldName: motiveName

--- a/tests/mocks/schemas/edit.yml
+++ b/tests/mocks/schemas/edit.yml
@@ -336,7 +336,7 @@ sections:
           - name: name
             component: Select
             componentAttributes:
-              isSearchable: true
+              isSearchable: false
               fieldHelp: Texto de ayuda visible en el tooltip.
               translateLabels: true
               labelFieldName: motiveName

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -545,6 +545,7 @@
               "name": "name",
               "component": "Select",
               "componentAttributes": {
+                "isSearchable": true,
                 "fieldHelp": "Texto de ayuda visible en el tooltip.",
                 "translateLabels": true,
                 "labelFieldName": "motiveName",

--- a/tests/mocks/schemas/expected/edit.json
+++ b/tests/mocks/schemas/expected/edit.json
@@ -545,7 +545,7 @@
               "name": "name",
               "component": "Select",
               "componentAttributes": {
-                "isSearchable": true,
+                "isSearchable": false,
                 "fieldHelp": "Texto de ayuda visible en el tooltip.",
                 "translateLabels": true,
                 "labelFieldName": "motiveName",


### PR DESCRIPTION
## Link al ticket
- [JMV-4053](https://janiscommerce.atlassian.net/browse/JMV-4053)

## Descripción del requerimiento
- Extender los componentes **Select** para que acepten de forma explícita y opcional el atributo **`isSearchable`** (booleano) en `componentAttributes`, alineado con el uso en vistas Janis (browse filtros y edit-new).
- Mantener los fixtures de prueba (`edit.yml` / `expected/edit.json`) coherentes con el nuevo atributo para que el build y la validación reflejen el contrato actualizado.

## Descripción de la solución
- Se añade la propiedad opcional `isSearchable: { type: 'boolean' }` en los esquemas de Select en:
  - `lib/schemas/browse/modules/filter-components/select.js`
  - `lib/schemas/browse/modules/filters/components/select.js`
  - `lib/schemas/edit-new/modules/components/selects.js`
- Se actualizan scjhemas de ejemplo: `isSearchable: false` en `componentAttributes` de un Select en `tests/mocks/schemas/edit.yml` y el mismo dato en `tests/mocks/schemas/expected/edit.json` 

## Cómo se puede probar?
- Ejecutar `npm run test` en la rama 
- Revisar que los schemas edit y los tres módulos de schema listados reflejan `isSearchable` donde corresponda.

## Changelog
```
### Added
Optional isSearchable (boolean) in select componentAttributes for browse filter-components select, browse filters select, and edit-new selects schemas; edit schemas aligned
```

[JMV-4053]: https://janiscommerce.atlassian.net/browse/JMV-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select and multiselect components now support an optional, configurable search feature that can be enabled or disabled on a per-component basis.

* **Tests**
  * Updated test schemas and fixtures to validate the new search configuration property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->