### PR TITLE
JMV-4066 | Permitir opciones dinámicas en select remoto del browse

### DIFF
--- a/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
+++ b/lib/schemas/browse/modules/filters/components/select-options/remoteOptions.js
@@ -23,7 +23,7 @@ module.exports = {
 			initialValuesFilterName: { type: 'string' },
 			initialValuesPathParam: { type: 'string' },
 			searchParam: { type: 'string', default: 'filters[search]' },
-			endpointParameters: getEndpointParameters(true),
+			endpointParameters: getEndpointParameters(false),
 			valuesMapper: {
 				type: 'object',
 				properties: {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -830,7 +830,7 @@
                 "dynamic": "filters.locationId"
               }
             },
-						{
+            {
               "name": "locationId",
               "target": "filter",
               "value": {

--- a/tests/mocks/schemas/browse.json
+++ b/tests/mocks/schemas/browse.json
@@ -782,6 +782,71 @@
       }
     },
     {
+      "name": "remoteMultiselectDynamicOptions",
+      "component": "Multiselect",
+      "componentAttributes": {
+        "translateLabels": false,
+        "options": {
+          "scope": "remote",
+          "endpoint": {
+            "service": "delivery",
+            "namespace": "carrier",
+            "method": "list"
+          },
+          "endpointParameters": [
+            {
+              "name": "locationId",
+              "target": "filter",
+              "value": {
+                "dynamic": "filters.locationId"
+              }
+            }
+          ],
+          "valuesMapper": {
+            "label": "name",
+            "value": "id"
+          },
+          "searchParam": "filters[search]"
+        }
+      }
+    },
+    {
+      "name": "remoteMultiselectStaticDynamicOptions",
+      "component": "Multiselect",
+      "componentAttributes": {
+        "translateLabels": false,
+        "options": {
+          "scope": "remote",
+          "endpoint": {
+            "service": "delivery",
+            "namespace": "carrier",
+            "method": "list"
+          },
+          "endpointParameters": [
+            {
+              "name": "locationId",
+              "target": "filter",
+              "value": {
+                "dynamic": "filters.locationId"
+              }
+            },
+						{
+              "name": "locationId",
+              "target": "filter",
+              "value": {
+                "static": "staticValue"
+              }
+            }
+          ],
+          "valuesMapper": {
+            "label": "name",
+            "value": "id"
+          },
+          "searchParam": "filters[search]"
+        }
+      }
+    },
+    {
       "name": "dateTimePickerFilter",
       "component": "DateTimePicker",
       "componentAttributes": {

--- a/tests/mocks/schemas/expected/browse.json
+++ b/tests/mocks/schemas/expected/browse.json
@@ -838,6 +838,73 @@
       }
     },
     {
+      "name": "remoteMultiselectDynamicOptions",
+      "component": "Multiselect",
+      "componentAttributes": {
+        "translateLabels": false,
+        "options": {
+          "scope": "remote",
+          "endpoint": {
+            "service": "delivery",
+            "namespace": "carrier",
+            "method": "list",
+            "resolve": true
+          },
+          "endpointParameters": [
+            {
+              "name": "locationId",
+              "target": "filter",
+              "value": {
+                "dynamic": "filters.locationId"
+              }
+            }
+          ],
+          "valuesMapper": {
+            "label": "name",
+            "value": "id"
+          },
+          "searchParam": "filters[search]"
+        }
+      }
+    },
+    {
+      "name": "remoteMultiselectStaticDynamicOptions",
+      "component": "Multiselect",
+      "componentAttributes": {
+        "translateLabels": false,
+        "options": {
+          "scope": "remote",
+          "endpoint": {
+            "service": "delivery",
+            "namespace": "carrier",
+            "method": "list",
+            "resolve": true
+          },
+          "endpointParameters": [
+            {
+              "name": "locationId",
+              "target": "filter",
+              "value": {
+                "dynamic": "filters.locationId"
+              }
+            },
+            {
+              "name": "locationId",
+              "target": "filter",
+              "value": {
+                "static": "staticValue"
+              }
+            }
+          ],
+          "valuesMapper": {
+            "label": "name",
+            "value": "id"
+          },
+          "searchParam": "filters[search]"
+        }
+      }
+    },
+    {
       "name": "dateTimePickerFilter",
       "component": "DateTimePicker",
       "componentAttributes": {
@@ -2450,7 +2517,7 @@
         "fontWeight": "normal"
       }
     },
-      {
+    {
       "name": "interactionExampleThree",
       "component": "Text",
       "attributes": {


### PR DESCRIPTION
## Link al ticket

- [JMV-4066](https://janiscommerce.atlassian.net/browse/JMV-4066)

## Descripción del requerimiento

- Permitir que los `endpointParameters` de un select remoto en el browse acepten valores dinámicos (provenientes de filtros activos) además de valores estáticos ya soportados.

## Criterios de aprobación

- El validador debe aceptar schemas de browse con `endpointParameters` cuyo `value` sea un objeto con clave `dynamic` (referenciando un filtro activo).
- El validador debe aceptar `endpointParameters` que combinen entradas con `value.dynamic` y `value.static` en el mismo array.
- Los casos de validación existentes no deben verse afectados.

## Descripción de la solución

- Se modificó la llamada a `getEndpointParameters` en `remoteOptions.js` pasando `false` en lugar de `true`, lo que hace que los parámetros del endpoint ya no sean requeridos en modo estricto y puedan aceptar valores dinámicos o estáticos.
- Se agregaron dos nuevos casos en los mocks de test: uno con `endpointParameters` dinámicos puros y otro combinando dinámico + estático.

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
|---|---|---|---|
| Schema de browse con `endpointParameters` con `value.dynamic` | Validación exitosa | ✅ | |
| Schema de browse con `endpointParameters` combinando `value.dynamic` y `value.static` | Validación exitosa | ✅ | |
| Schemas de browse existentes sin `endpointParameters` dinámicos | Sin regresiones | ✅ | |

### Links de prueba:
- N/A — librería de validación de schemas, no tiene entorno de ejecución propio.

## Evidencias, pruebas de cómo funciona

-

## Link a la documentación

- N/A

## Datos extra a tener en cuenta

- El cambio en `remoteOptions.js` es mínimo (un boolean en `getEndpointParameters`), pero habilita que el campo `value` dentro de cada item de `endpointParameters` pueda ser `{ dynamic: "filters.someField" }` además de `{ static: "someValue" }`.

## CHANGELOG:

```javascript
### Changed
- \`getEndpointParameters\` now accepts dynamic and static values in remote select \`endpointParameters\` for browse filters [JMV-4066](https://janiscommerce.atlassian.net/browse/JMV-4066)
````

[JMV-4066]: https://janiscommerce.atlassian.net/browse/JMV-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JMV-4066]: https://janiscommerce.atlassian.net/browse/JMV-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ