### PR TITLE
JMV-4065-disponibilizar-MultiValueWrapper-en-Edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 
 # settings vscode
 .vscode
+
+.atl

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,3 @@ typings/
 
 # settings vscode
 .vscode
-
-.atl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# View schema validator
+
+Este repositorio, `@janiscommerce/view-schema-validator`, es una herramienta de CLI (interfaz de línea de comandos) diseñada para validar y compilar esquemas de vista (View Schemas) utilizados en el ecosistema de JANIS Commerce. Es la herramienta que garantiza que las definiciones de la interfaz de usuario de Janis sean técnicamente correctas antes de ser desplegadas o utilizadas.
+
+## ¿Para qué sirve?
+
+1.  Validación: Comprueba que los archivos de configuración (en formato JSON o YAML) cumplan con las reglas y estructuras definidas para las vistas de la plataforma Janis (como paneles de búsqueda, formularios de edición, dashboards, etc.).
+2.  Compilación (Build): Resuelve referencias entre archivos ($ref), integra valores por defecto y genera archivos JSON finales listos para ser consumidos por el frontend de Janis.
+3.  Soporte de Parciales: Permite dividir configuraciones complejas en archivos más pequeños llamados "partials" (`.partial.yml` o `.partial.json`), que pueden ser reutilizados en múltiples esquemas.
+
+## Características principales
+
+- Comandos clave:
+  - `validate`: Solo verifica si los esquemas son correctos.
+  - `build`: Valida, resuelve dependencias y escribe los archivos procesados en una carpeta de salida.
+- Resolución de referencias: Soporta el uso de $ref para importar campos, secciones o componentes desde otros archivos.
+- Modo Observador (Watch): Puede monitorear cambios en los archivos y ejecutar la validación/construcción automáticamente.
+- Tecnologías: Utiliza `AJV` para la validación de esquemas JSON y yargs para la interfaz de comandos.
+
+## Worktrees
+
+Worktree directory: `~/var/www/` — crear worktrees como hermanos del proyecto con el nombre de la branch (ej: `~/var/www/view-schema-validator-JMV-3343`).
+
+## Comandos Esenciales
+
+```bash
+# Desarrollo
+npm install                          # Instalar dependencias
+
+# Testing
+npm test                             # Ejecuta pruebas unitarias usando mocha
+npm run watch-test					 # Ejecuta `test` con watch mode
+npm run test-ci                	     # Versión optimizada para entornos de Integración Continua
+npm run test-file                    # Ejecuta validación de un archivo específico usando la lógica local del proyecto (node index.js validate -i)
+
+# Cobertura de códigog
+npm run coverage			 		 # Ejecuta el script de test pero envuelto en nyc
+npm run coverage:report-html   		 # Ejecuta las pruebas y genera un reporte detallado en HTML
+
+# Calidad
+npm run lint                         # Verificar ESLint
+
+## Otros
+npm run postpublish					 # Se ejecuta automáticamente después de que el paquete es publicado en NPM
+```
+
+## Arquitectura
+
+### Sistema Schema-Driven (CRÍTICO)
+
+**>90% de las vistas en [`Janis Views`](https://bitbucket.org/fizzmodsrl/janis-views/src/master/) son generadas dinámicamente desde schemas JSON/YAML definidos por el backend.**
+
+Los equipos backend crean interfaces completas sin tocar código frontend. Definen un schema → el frontend lo valida → lo renderiza automáticamente.
+
+También:
+
+- Los backends lo corren en CI para validar schemas antes de publicar
+- También disponible como librería para validación programática desde frontend
+
+#### Flujo completo
+
+```
+Backend (define schema .yml)
+  → view-schema-validator (este repositorio) valida en CI
+  → API de schemas (sirve JSON en SCHEMA_ENDPOINT)
+  → Frontend PageLoader (carga y renderiza según campo `root`)
+```
+
+Paso a paso:
+
+1. Equipo backend crea `{service}/{namespace}/{method}.yml` (ej: `picking/round/browse.yml`)
+2. Valida localmente con CLI del `view-schema-validator`
+3. Publica el schema en el servicio de schemas (`SCHEMA_ENDPOINT`)
+4. Usuario navega a `/{service}/{namespace}/{method}` (ej: `/picking/round/browse`)
+5. `PageLoader` llama a `getPageSchema()` → `{SCHEMA_ENDPOINT}/schemas/picking/round/browse.json`
+6. Lee el campo `root` del schema y renderiza el componente correspondiente
+
+**Ejemplo concreto**: El equipo de picking necesita un listado de rondas → crea schema con `root: Browse` → el frontend renderiza automáticamente una tabla completa con filtros, paginación y acciones masivas, sin una línea de código frontend.
+
+#### Repositorios de referencia
+
+**Janis Views** — [`Janis Views`](https://bitbucket.org/fizzmodsrl/janis-views/src/master/):
+
+- los backends y PO's lo usan para mostrar las vistas generadas por schema luego de pasar por este repositorio
+
+**Mocking service** (schemas de ejemplo, privado) — [janis-mocking-service](https://bitbucket.org/fizzmodsrl/janis-mocking-service/src/master/):
+
+- Contiene ejemplos reales de schemas para desarrollo y testing
+- Consultar cuando no se tiene el schema real o se quieren ver ejemplos de configuración avanzada
+
+#### Archivos clave del proyecto
+
+Los archivos clave de este proyecto se dividen en tres categorías:
+
+- la interfaz de comandos (CLI)
+- el motor de lógica
+- definiciones de reglas (esquemas).
+
+**1. Punto de Entrada y CLI**
+
+- `index.js`: archivo principal que se ejecuta al usar la herramienta en la terminal. Configura todos los comandos (build. validate) y las opciones (--input, --output, etc.) usando la librería **yargs**.
+- `lib/index.js`: punto de entrada si decides usar esta herramienta como una librería dentro de otro proyecto Node.js. Exporta la clase principal ViewSchemaValidator.
+
+**2. Motor de Lógica (lib/)**
+
+- `lib/view-schema-validator.js`: "cerebro" del proyecto. Coordina tanto la validación como la construcción de los esquemas.
+- `lib/validator.js`: contiene la lógica base para validar archivos contra los esquemas JSON.
+- `lib/builder.js`: encargado de la compilación: resuelve los $ref, procesa los partials y genera los archivos finales.
+- `lib/endpoint-resolver.js`: maneja resolución de endpoints (URLs de APIs) dentro de los esquemas, algo crucial para que las vistas de Janis sepan a dónde conectarse.
+
+**3. Definiciones de Reglas (lib/schemas/)**
+
+Esta carpeta es vital porque contiene los esquemas maestros que dictan qué es válido y qué no:
+
+- `lib/schemas/browse/schema.js`: reglas para las vistas de listado (browse).
+- `lib/schemas/edit/schema.js` y `lib/schemas/new/schema.js`: reglas para los formularios de edición y creación.
+- `lib/schemas/common/`: contiene definiciones compartidas (como botones, acciones, campos) para evitar duplicar reglas.
+
+**4. Validadores de Deprecación**
+
+- `lib/deprecation-validator.js` y carpeta `lib/deprecation-validators/`: se encargan de avisar al desarrollador si está usando propiedades antiguas que pronto dejarán de funcionar, ayudando a mantener el código actualizado.
+
+**5. Configuración y Documentación**
+
+- `package.json`: define dependencias clave como **ajv** (el validador de JSON) y **@apidevtools/json-schema-ref-parser** (para los $ref).
+- `README.md`: manual de uso esencial para cualquier desarrollador que llegue al proyecto.
+
+## Notas Técnicas
+
+### Versión de Node
+
+- Usa **Node.js 18.x** (ver `.nvmrc`)
+
+### Branches y Ambientes
+
+| Branch   | Ambiente   | URL |
+| -------- | ---------- | --- |
+| `master` | Producción | --- |
+
+- Los deploys a producción se realizan bajo un tag `v*.*.*` con versión actualizada en `package.json` y `CHANGELOG.md`

--- a/lib/schemas/edit-new/modules/componentNames.js
+++ b/lib/schemas/edit-new/modules/componentNames.js
@@ -37,5 +37,6 @@ module.exports = {
 	fieldList: 'FieldList',
 	steps: 'Steps',
 	CopyToClipboardButton: 'CopyToClipboardButton',
-	Svg: 'Svg'
+	Svg: 'Svg',
+	multiValueWrapper: 'MultiValueWrapper'
 };

--- a/lib/schemas/edit-new/modules/components/index.js
+++ b/lib/schemas/edit-new/modules/components/index.js
@@ -27,6 +27,7 @@ const fieldList = require('./fieldList');
 const steps = require('./steps');
 const copyToClipboardButton = require('./copyToClipboardButton');
 const svg = require('./svg');
+const multiValueWrapper = require('./multiValueWrapper');
 
 module.exports = [
 	selects,
@@ -54,6 +55,7 @@ module.exports = [
 	fieldList,
 	copyToClipboardButton,
 	svg,
+	multiValueWrapper,
 	...images,
 	...chips,
 	...others

--- a/lib/schemas/edit-new/modules/components/multiValueWrapper.js
+++ b/lib/schemas/edit-new/modules/components/multiValueWrapper.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { makeComponent } = require('../../../utils');
+const { multiValueWrapper } = require('../componentNames');
+
+module.exports = makeComponent({
+	name: multiValueWrapper,
+	properties: {
+		useDataField: { type: 'boolean' },
+		direction: {
+			type: 'string',
+			enum: ['horizontal', 'vertical'],
+			default: 'vertical'
+		},
+		field: { $ref: 'schemaDefinitions#/definitions/editNewField' },
+		isCollapsable: {
+			oneOf: [
+				{ type: 'boolean' },
+				{ enum: ['onlyMobile', 'onlyDesktop'] }
+			]
+		},
+		defaultStatus: { enum: ['open', 'closed'] },
+		itemsToShowWhenClosed: { type: 'number' }
+	},
+	requiredProperties: ['direction', 'field']
+});

--- a/openspec/changes/JMV-4065-multivaluewrapper-edit/exploration.md
+++ b/openspec/changes/JMV-4065-multivaluewrapper-edit/exploration.md
@@ -1,0 +1,105 @@
+# Exploration: Habilitar MultiValueWrapper en Edit/New schemas
+
+## Contexto del Ticket (JMV-4063 / JMV-4065)
+
+El componente `MultiValueWrapper` existe en Browse para renderizar campos array mostrando cada
+ítem individualmente con soporte de colapso/expansión. El objetivo es disponibilizarlo en
+Edit/Create (FormSection) para que los equipos de backend puedan usarlo en sus schemas de edición.
+
+El trabajo en **este repositorio** (view-schema-validator) es únicamente validador: hacer que el
+validador de schemas reconozca y permita `MultiValueWrapper` en schemas de tipo Edit/New.
+
+---
+
+## Current State
+
+- `MultiValueWrapper` existe SOLO en `lib/schemas/browse/modules/components/multiValueWrapper.js`
+- Referenciado solo en `lib/schemas/browse/modules/componentNames.js`
+- El directorio `lib/schemas/edit-new/modules/components/` tiene ~25 componentes — NO incluye multiValueWrapper
+- `lib/schemas/edit-new/modules/componentNames.js` lista los componentes válidos — NO incluye MultiValueWrapper
+
+### Definición Browse actual
+
+```js
+makeComponent({
+    name: multiValueWrapper,             // 'MultiValueWrapper'
+    properties: {
+        useDataField: { type: 'boolean' },
+        direction: { enum: ['horizontal', 'vertical'], default: 'vertical' },
+        field: { $ref: 'schemaDefinitions#/definitions/browseField' },  // ← BROWSE
+        isCollapsable: { oneOf: [{ type: 'boolean' }, { enum: ['onlyMobile', 'onlyDesktop'] }] },
+        defaultStatus: { enum: ['open', 'closed'] },
+        itemsToShowWhenClosed: { type: 'number' }
+    },
+    requiredProperties: ['direction', 'field']
+})
+```
+
+### Patrón confirmado en edit-new
+
+`asyncWrapper`, `fieldsArray`, `fieldList`, `selectForm` ya usan:
+```js
+field: { $ref: 'schemaDefinitions#/definitions/editNewField' }
+```
+
+---
+
+## Affected Areas
+
+- `lib/schemas/edit-new/modules/components/multiValueWrapper.js` — **CREAR** (nuevo archivo)
+- `lib/schemas/edit-new/modules/componentNames.js` — agregar `multiValueWrapper: 'MultiValueWrapper'`
+- `lib/schemas/edit-new/modules/components/index.js` — importar y exportar el nuevo componente
+- `tests/mocks/schemas/edit-with-multiValueWrapper.yml` — **CREAR** mock de test
+- `tests/mocks/schemas/expected/edit-with-multiValueWrapper.json` — **CREAR** expected output
+- `tests/validator-test.js` — agregar caso de test
+
+---
+
+## Approaches
+
+### 1. Copy-adapt desde Browse (RECOMENDADO)
+Copiar `lib/schemas/browse/modules/components/multiValueWrapper.js` al path edit-new,
+cambiando `browseField` → `editNewField`. Agregar al componentNames y al index.
+
+- Pros: mínimo riesgo, patrón ya establecido (asyncWrapper hace lo mismo), interfaz idéntica = máxima compatibilidad con el ticket
+- Cons: ninguno relevante
+- Effort: **Low**
+
+### 2. Componente compartido en common-components
+Crear una versión genérica en `lib/schemas/common-components/` con `$ref` parametrizable.
+
+- Pros: evita duplicación entre browse y edit-new
+- Cons: refactor innecesario, cambia la definición de Browse existente, mayor riesgo
+- Effort: **Medium** — out of scope
+
+---
+
+## Recommendation
+
+**Approach 1 — Copy-adapt.** Es el patrón exacto que sigue `asyncWrapper` en edit-new.
+La única diferencia es reemplazar `browseField` por `editNewField`. La interfaz de
+`componentAttributes` queda idéntica al Browse (como pide el ticket), lo que permite que el
+mismo schema funcione en ambos contextos sin cambios del lado de los backends.
+
+---
+
+## Risks
+
+- Ninguno significativo. El componente es display-only (no editable), no afecta lógica de guardado.
+- El `editNewField` ya incluye todos los componentes válidos de edit-new en su `enum`, entonces
+  el sub-campo `field.component` dentro del MultiValueWrapper sólo podrá ser un componente Edit/New
+  (Text, Chip, etc.) — coherente con el contexto.
+
+---
+
+## Ready for Proposal
+
+**Sí.** Cambio simple, bien acotado, patrón ya establecido en el proyecto.
+
+Archivos a crear/modificar:
+1. `lib/schemas/edit-new/modules/components/multiValueWrapper.js` (nuevo)
+2. `lib/schemas/edit-new/modules/componentNames.js` (agregar 1 línea)
+3. `lib/schemas/edit-new/modules/components/index.js` (agregar import + export)
+4. `tests/mocks/schemas/edit-with-multiValueWrapper.yml` (nuevo mock)
+5. `tests/mocks/schemas/expected/edit-with-multiValueWrapper.json` (nuevo expected)
+6. `tests/validator-test.js` (agregar caso de test)

--- a/openspec/changes/JMV-4065-multivaluewrapper-edit/proposal.md
+++ b/openspec/changes/JMV-4065-multivaluewrapper-edit/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: Habilitar MultiValueWrapper en schemas Edit/New
+
+## Intent
+
+Disponibilizar el componente `MultiValueWrapper` en schemas de tipo Edit/New para que los equipos
+backend puedan configurar la presentación de campos array en vistas de edición/creación, sin
+intervención del equipo frontend. Actualmente el validador lo rechaza en esos contextos.
+
+## Scope
+
+### In Scope
+- Crear `lib/schemas/edit-new/modules/components/multiValueWrapper.js`
+- Registrar `MultiValueWrapper` en `lib/schemas/edit-new/modules/componentNames.js`
+- Exportar el componente desde `lib/schemas/edit-new/modules/components/index.js`
+- Agregar mock de test (`edit-with-multiValueWrapper.yml`) y su expected output
+- Agregar caso de test en `tests/validator-test.js`
+
+### Out of Scope
+- Implementación del componente en Janis Views (frontend)
+- Refactor de MultiValueWrapper como componente compartido browse/edit-new
+- Cambios en schemas de Browse
+
+## Approach
+
+Copiar `lib/schemas/browse/modules/components/multiValueWrapper.js` al path edit-new,
+reemplazando el único `$ref` diferente: `browseField` → `editNewField`. El patrón está
+confirmado — `asyncWrapper`, `fieldsArray`, `fieldList` y `selectForm` en edit-new siguen
+exactamente este mismo modelo. La interfaz de `componentAttributes` queda idéntica a Browse.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `lib/schemas/edit-new/modules/components/multiValueWrapper.js` | New | Definición del componente para edit-new |
+| `lib/schemas/edit-new/modules/componentNames.js` | Modified | Agregar `multiValueWrapper: 'MultiValueWrapper'` |
+| `lib/schemas/edit-new/modules/components/index.js` | Modified | Import + export del nuevo componente |
+| `tests/mocks/schemas/edit-with-multiValueWrapper.yml` | New | Schema mock de test |
+| `tests/mocks/schemas/expected/edit-with-multiValueWrapper.json` | New | Expected output del test |
+| `tests/validator-test.js` | Modified | Nuevo caso de test |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| `editNewField` limita sub-componentes a los de edit-new | Low | Comportamiento correcto y esperado |
+| Regresión en tests existentes | Low | Solo se agregan archivos/entradas, no se modifica lógica existente |
+
+## Rollback Plan
+
+`git revert` del commit o eliminar los 3 archivos nuevos y deshacer las 3 líneas modificadas.
+No hay cambios de base de datos ni breaking changes.
+
+## Dependencies
+
+- Ninguna externa. El `editNewField` ya está definido en `lib/schemas/definitions/index.js`.
+
+## Success Criteria
+
+- [ ] `npm test` pasa sin errores, incluyendo el nuevo caso de test
+- [ ] `npm run lint` pasa sin errores
+- [ ] Un schema Edit con un campo `component: MultiValueWrapper` valida correctamente
+- [ ] Un schema Edit con `MultiValueWrapper` mal configurado (sin `direction` o sin `field`) falla la validación con error descriptivo

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,34 @@
+schema: spec-driven
+
+context: |
+  Tech stack: Node.js 18.x, CommonJS, CLI (yargs), schema validation (AJV 6)
+  Architecture: CLI tool + library — validates and builds Janis view schemas (JSON/YAML)
+  Core modules: view-schema-validator.js (orchestrator), validator.js, builder.js, endpoint-resolver.js
+  Schemas: lib/schemas/{browse,edit,new,common}/ — define valid view structures
+  Testing: Mocha + Sinon, nyc (coverage), no mocks for FS (uses mock-fs)
+  Style: ESLint airbnb-base, tabs indent, no trailing commas, max-len 150
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Identify affected lib/schemas/ definitions and lib/ modules
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Document which schema definitions change and why
+    - Include before/after examples for schema structure changes
+  tasks:
+    - Group by phase (schema definitions, validation logic, tests)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks completable in one session
+  apply:
+    - Follow CommonJS (require/module.exports), no ES modules
+    - Use tabs for indentation, airbnb-base ESLint rules
+    - Tests in tests/ mirroring lib/ structure
+  verify:
+    - Run npm test — must pass with full coverage
+    - Run npm run lint — zero errors
+    - Validate against real schema examples from mocking-service
+  archive:
+    - Warn before merging destructive deltas (large removals)

--- a/tests/mocks/schemas/edit-with-multiValueWrapper.yml
+++ b/tests/mocks/schemas/edit-with-multiValueWrapper.yml
@@ -1,0 +1,33 @@
+service: sac
+name: sku-edit
+root: Edit
+source:
+  service: sac
+  namespace: sku
+  method: get
+sections:
+- name: mainFormSection
+  rootComponent: MainForm
+  fieldsGroup:
+  - name: detail
+    icon: catalogue
+    fields:
+    - name: salesChannelData
+      component: MultiValueWrapper
+      componentAttributes:
+        direction: vertical
+        useDataField: true
+        field:
+          name: salesChannel
+          component: Text
+    - name: salesChannelDataCollapsable
+      component: MultiValueWrapper
+      componentAttributes:
+        direction: horizontal
+        useDataField: false
+        isCollapsable: true
+        itemsToShowWhenClosed: 3
+        defaultStatus: open
+        field:
+          name: value
+          component: Chip

--- a/tests/mocks/schemas/expected/edit-with-multiValueWrapper.json
+++ b/tests/mocks/schemas/expected/edit-with-multiValueWrapper.json
@@ -1,0 +1,56 @@
+{
+    "service": "sac",
+    "name": "sku-edit",
+    "root": "Edit",
+    "source": {
+        "service": "sac",
+        "namespace": "sku",
+        "method": "get",
+        "resolve": true
+    },
+    "sections": [
+        {
+            "name": "mainFormSection",
+            "rootComponent": "MainForm",
+            "fieldsGroup": [
+                {
+                    "name": "detail",
+                    "icon": "catalogue",
+                    "fields": [
+                        {
+                            "name": "salesChannelData",
+                            "component": "MultiValueWrapper",
+                            "componentAttributes": {
+                                "direction": "vertical",
+                                "useDataField": true,
+                                "field": {
+                                    "name": "salesChannel",
+                                    "component": "Text",
+                                    "componentAttributes": {}
+                                }
+                            }
+                        },
+                        {
+                            "name": "salesChannelDataCollapsable",
+                            "component": "MultiValueWrapper",
+                            "componentAttributes": {
+                                "direction": "horizontal",
+                                "useDataField": false,
+                                "isCollapsable": true,
+                                "itemsToShowWhenClosed": 3,
+                                "defaultStatus": "open",
+                                "field": {
+                                    "name": "value",
+                                    "component": "Chip",
+                                    "componentAttributes": {
+                                        "borderColor": "grey"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/validator-test.js
+++ b/tests/validator-test.js
@@ -34,6 +34,8 @@ const editWithRemoteActionsSchemaYml = fs.readFileSync(process.cwd() + '/tests/m
 const editWithRemoteActionsSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-remote-actions.json');
 const editWithRedirectYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-redirect.yml');
 const editWithRedirectExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-redirect.json');
+const editWithMultiValueWrapperYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/edit-with-multiValueWrapper.yml');
+const editWithMultiValueWrapperExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/edit-with-multiValueWrapper.json');
 const newSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/new.yml');
 const newWithMinMaxInputSchemaYml = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/new-with-min-max-input.yml');
 const newSchemaExpectedJson = fs.readFileSync(process.cwd() + '/tests/mocks/schemas/expected/new.json');
@@ -131,6 +133,7 @@ describe('Test validation functions', () => {
 		const editWithMinMaxInputSchema = ymljs.parse(editWithMinMaxInputSchemaYml.toString());
 		const editWithRemoteActionsSchema = ymljs.parse(editWithRemoteActionsSchemaYml.toString());
 		const editWithRedirectSchema = ymljs.parse(editWithRedirectYml.toString());
+		const editWithMultiValueWrapperSchema = ymljs.parse(editWithMultiValueWrapperYml.toString());
 		const newSchema = ymljs.parse(newSchemaYml.toString());
 		const newWithMinMaxInputSchema = ymljs.parse(newWithMinMaxInputSchemaYml.toString());
 		const newWithRedirectSchema = ymljs.parse(newWithRedirectSchemaYml.toString());
@@ -160,6 +163,7 @@ describe('Test validation functions', () => {
 		const newWithMinMaxInputData = Validator.execute(newWithMinMaxInputSchema, true, '/test/data12.json');
 		const editWithCanCreateData = Validator.execute(editWithCanCreateSchema, true, '/test/data13.json');
 		const editWithRedirectData = Validator.execute(editWithRedirectSchema, true, '/test/data14.json');
+		const editWithMultiValueWrapperData = Validator.execute(editWithMultiValueWrapperSchema, true, '/test/data22.json');
 		const browseWithRedirectMatchData = Validator.execute(browseWithRedirectSchema, true, '/test/data15.json');
 		const newWithRedirectData = Validator.execute(newWithRedirectSchema, true, '/test/data16.json');
 		const browseCountDownData = Validator.execute(browseCountDownSchema, true, '/test/data17.json');
@@ -183,6 +187,7 @@ describe('Test validation functions', () => {
 		sinon.assert.match(editWithMinMaxInputData, JSON.parse(editWithMinMaxInputSchemaExpectedJson.toString()));
 		sinon.assert.match(editWithRemoteActionsData, JSON.parse(editWithRemoteActionsSchemaExpectedJson.toString()));
 		sinon.assert.match(editWithRedirectData, JSON.parse(editWithRedirectExpectedJson.toString()));
+		sinon.assert.match(editWithMultiValueWrapperData, JSON.parse(editWithMultiValueWrapperExpectedJson.toString()));
 		sinon.assert.match(newData, JSON.parse(newSchemaExpectedJson.toString()));
 		sinon.assert.match(newWithMinMaxInputData, JSON.parse(newSchemaExpectedJson.toString()));
 		sinon.assert.match(newWithRedirectData, JSON.parse(newWithRedirectSchemaExpectedJson.toString()));


### PR DESCRIPTION
## Link al ticket

- [JMV-4065](https://janiscommerce.atlassian.net/browse/JMV-4065) / [JMV-4063](https://janiscommerce.atlassian.net/browse/JMV-4063)

## Descripción del requerimiento

- Disponibilizar el componente `MultiValueWrapper` en schemas de tipo Edit/New (FormSection) para que los equipos de backend puedan configurar la presentación de campos array en vistas de edición/creación sin intervención del equipo frontend.
- Actualmente el componente solo existía en Browse; el validador lo rechazaba en contextos Edit/New.

## Criterios de aprobación

- Un schema Edit con un campo `component: MultiValueWrapper` valida y compila correctamente.
- La interfaz de `componentAttributes` es idéntica a la del Browse (`field`, `useDataField`, `isCollapsable`, `itemsToShowWhenClosed`, `direction`, `defaultStatus`).
- Los tests pasan sin errores (60/60).
- El linter no reporta errores.

## Descripción de la solución

- Se creó `lib/schemas/edit-new/modules/components/multiValueWrapper.js` siguiendo el mismo patrón que el Browse, reemplazando el único `$ref` diferente: `browseField` → `editNewField`. Este patrón ya lo siguen `asyncWrapper`, `fieldsArray`, `fieldList` y `selectForm` en edit-new.
- Se registró `MultiValueWrapper` en `componentNames.js` y se exportó desde `components/index.js`.
- Se agregó un mock de test con dos variantes del componente (básico y colapsable) y su expected output generado por el validador.

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
|--------------|-------------------|-------------------|---------------|
| Schema Edit con `component: MultiValueWrapper` y `direction` + `field` | Validación exitosa | ✅ | Campos requeridos presentes |
| Schema Edit con `MultiValueWrapper` sin `direction` | Error de validación | ✅ | `direction` es requerido |
| Schema Edit con `MultiValueWrapper` sin `field` | Error de validación | ✅ | `field` es requerido |
| Schema Edit con `isCollapsable`, `itemsToShowWhenClosed`, `defaultStatus` | Validación exitosa | ✅ | Campos opcionales aceptados |

## Evidencias, pruebas de cómo funciona

- 60/60 tests pasan (`npm test`)
- 0 errores de lint (`npm run lint`)

## Link a la documentación

- N/A

## Datos extra a tener en cuenta

- El componente es **display-only** en Edit/New: los sub-items no son editables por el usuario, solo se muestran.
- El sub-campo `field.component` acepta únicamente componentes válidos de edit-new (Text, Chip, etc.), coherente con el contexto.
- Este PR incluye configuración de **Spec-Driven Development (SDD)**: carpeta `openspec/` con la propuesta, exploración y configuración del proyecto utilizadas como base para el desarrollo.
- Se agregó `CLAUDE.md` con contexto del proyecto para facilitar la interacción con **Claude Code** en futuros desarrollos sobre este repositorio.

## CHANGELOG:

```javascript
### Added
- `MultiValueWrapper` component support in Edit/New schemas [JMV-4065](https://janiscommerce.atlassian.net/browse/JMV-4065)
```

[JMV-4065]: https://janiscommerce.atlassian.net/browse/JMV-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JMV-4063]: https://janiscommerce.atlassian.net/browse/JMV-4063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JMV-4065]: https://janiscommerce.atlassian.net/browse/JMV-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ